### PR TITLE
Patch .htaccess compatibility

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,2 @@
+RewriteEngine on
+RewriteRule ^api/ api.php

--- a/api.php
+++ b/api.php
@@ -1116,6 +1116,12 @@ class REST_CRUD_API {
 
 		// connect
 		$request = trim($request,'/');
+		// Fix for compatibility with .htaccess 
+		if($request==''){
+			// Obtain names of tables for request
+			$request = preg_replace('/\/\w+\//','',$_SERVER['REQUEST_URI']);
+			$request = preg_replace('/[?][\s\S]+/','',$request);
+		}
 		if (!$database) {
 			$database  = $this->parseRequestParameter($request, 'a-zA-Z0-9\-_');
 		}


### PR DESCRIPTION
First sorry for my bad English, I am trying to include in your API a .htaccess compatibility to add a new way to call it.

Actual way: http://localhost/**api/api.php**/categories?filter[]=id,eq,1&filter[]=id,eq,3&satisfy=any
New way: http://localhost/**api/**categories?filter[]=id,eq,1&filter[]=id,eq,3&satisfy=any

Can you check this patch?

Thank you.