### PR TITLE
Exit statuses should be in the range 0 to 254

### DIFF
--- a/api.php
+++ b/api.php
@@ -2087,7 +2087,10 @@ class PHP_API_AUTH {
 // 	'secret'=>'someVeryLongPassPhraseChangeMe',
 // ));
 // $auth->executeCommand();
-// if (empty($_SESSION['user'])) exit(403);
+// if (empty($_SESSION['user'])) {
+//	header('HTTP/1.0 403 Forbidden');
+//	exit(0);
+// }
 
 // uncomment the lines below for form+session based authentication (see "login.html"):
 
@@ -2095,7 +2098,10 @@ class PHP_API_AUTH {
 // 	'authenticator'=>function($user,$pass){ $_SESSION['user']=($user=='admin' && $pass=='admin'); }
 // ));
 // $auth->executeCommand();
-// if (empty($_SESSION['user'])) exit(403);
+// if (empty($_SESSION['user'])) {
+//	header('HTTP/1.0 403 Forbidden');
+//	exit(0);
+// }
 
 // uncomment the lines below when running in stand-alone mode:
 


### PR DESCRIPTION
I would expect a 403 header if authentication fails
Exit the program with a 403 is an invalid exit status.
According to http://php.net/manual/en/function.exit.php exit statuses should be in the range 0 to 254.
Because exit does not throw a header, you can not redirect users to a login page, when trying to call the api.php script