### PR TITLE
1st attempt at adding exclude= (issue #136)

### DIFF
--- a/tests/tests.php
+++ b/tests/tests.php
@@ -357,6 +357,20 @@ class PHP_CRUD_API_Test extends PHPUnit_Framework_TestCase
 		$test->expect('{"posts":{"columns":["id","user_id","category_id","content"],"records":[[14,1,1,"#10"]],"results":11}}');
 	}
 
+	public function testListExampleFromReadmeFullRecord()
+	{
+		$test = new API($this);
+		$test->get('/posts?filter=id,eq,1');
+		$test->expect('{"posts":{"columns":["id","user_id","category_id","content"],"records":[[1,1,1,"blog started"]]}}');
+	}
+
+	public function testListExampleFromReadmeWithExclude()
+	{
+		$test = new API($this);
+		$test->get('/posts?exclude=id&filter=id,eq,1');
+		$test->expect('"posts":{"columns":["user_id","category_id","content"],"records":[[1,1,"blog started"]]}}');
+	}
+
 	public function testListExampleFromReadme()
 	{
 		$test = new API($this);
@@ -368,6 +382,13 @@ class PHP_CRUD_API_Test extends PHPUnit_Framework_TestCase
 	{
 		$test = new API($this);
 		$test->get('/posts?include=categories,tags,comments&filter=id,eq,1&transform=1');
+		$test->expect('{"posts":[{"id":1,"post_tags":[{"id":1,"post_id":1,"tag_id":1,"tags":[{"id":1,"name":"funny"}]},{"id":2,"post_id":1,"tag_id":2,"tags":[{"id":2,"name":"important"}]}],"comments":[{"id":1,"post_id":1,"message":"great"},{"id":2,"post_id":1,"message":"fantastic"}],"user_id":1,"category_id":1,"categories":[{"id":1,"name":"announcement","icon":null}],"content":"blog started"}]}');
+	}
+
+	public function testListExampleFromReadmeWithTransformWithExclude()
+	{
+		$test = new API($this);
+		$test->get('/posts?include=categories,tags,comments&exclude=comments.message&filter=id,eq,1&transform=1');
 		$test->expect('{"posts":[{"id":1,"post_tags":[{"id":1,"post_id":1,"tag_id":1,"tags":[{"id":1,"name":"funny"}]},{"id":2,"post_id":1,"tag_id":2,"tags":[{"id":2,"name":"important"}]}],"comments":[{"id":1,"post_id":1,"message":"great"},{"id":2,"post_id":1,"message":"fantastic"}],"user_id":1,"category_id":1,"categories":[{"id":1,"name":"announcement","icon":null}],"content":"blog started"}]}');
 	}
 


### PR DESCRIPTION
Feel free to change the behavior if this is undesired.   This adds the exclude= parameter.  I added a few tests to demonstrate the behavior.  If both include and exclude are present, then include is run first pulling in any relations and then exclude is run.   If there are multiple tables in the return, the exclude parameter must be in the format {table}.{column/field}.  If there is a single table in the return, the exclude parameter may just be {column/field}.   This could be improved to exclude entire tables, say {table}.*?.   Some exclusions have unintended behavior.  For example, if you change the test from &exclude=comments.message to &exclude=category.id, it will drop all the fields from category instead of just removing category.id.   Otherwise, it works for general cases.