### PR TITLE
Database column type in metadata

### DIFF
--- a/api.php
+++ b/api.php
@@ -88,7 +88,15 @@ class MySQL implements DatabaseInterface {
 					k2."REFERENCED_TABLE_SCHEMA" = ? AND
 					k1."TABLE_NAME" COLLATE \'utf8_bin\' = k2."TABLE_NAME" COLLATE \'utf8_bin\' AND
 					k1."REFERENCED_TABLE_NAME" COLLATE \'utf8_bin\' = ? AND
-					k2."REFERENCED_TABLE_NAME" COLLATE \'utf8_bin\' IN ?'
+					k2."REFERENCED_TABLE_NAME" COLLATE \'utf8_bin\' IN ?',
+			'reflect_type'=> 'SELECT 
+					"COLUMN_NAME", "COLUMN_TYPE" 
+				FROM 
+					"INFORMATION_SCHEMA"."COLUMNS" 
+				WHERE 
+					"TABLE_SCHEMA" = ? AND 
+					"TABLE_NAME" = ?
+			'
 		);
 	}
 
@@ -2217,6 +2225,11 @@ class PHP_CRUD_API {
 				foreach ($primaryKeys as $primaryKey) {
 					$table_fields[$table['name']][$primaryKey]->primaryKey = true;
 				}
+				$result = $this->db->query($this->db->getSql('reflect_type'),array($database,$table_list[0]));
+				while ($row = $this->db->fetchRow($result)) {
+					$expl = explode('(',$row[1]);
+					$table_fields[$table['name']][$row[0]]->type = $expl[0];					
+				}
 			}
 
 			foreach (array('root_actions','id_actions') as $path) {
@@ -2341,6 +2354,9 @@ class PHP_CRUD_API {
 							if ($k>0) echo ',';
 							echo '"'.$field.'": {';
 							echo '"type": "string"';
+							if (isset($action['fields'][$field]->type)) {
+								echo ',"db-type": '.json_encode($action['fields'][$field]->type);
+							}
 							if (isset($action['fields'][$field]->referenced)) {
 								echo ',"x-referenced": '.json_encode($action['fields'][$field]->referenced);
 							}


### PR DESCRIPTION
First of all, thanks for building this great php api framework and sharing it with the world!

I am a SAP Developer mainly developping JS apps in [SAPUI5 / OpenUI5](https://open.sap.com/)
In order to make SAPUI5 work with your API, I have made a [SAPui5 model implementation](https://github.com/VyseExhale/OpenUI5-SAPUI5-CRUDModel) of your api
With this model I can retrieve, edit and send data to your api and bind it to my views.

Other SAPui5 Models (like Odata) auto convert api response data to usable js json objects.
for example. Any date/time fields in the api will in js be converted to a new Date() object.

I wanted to do this too with my model implementation of your api.. 
In order to do that, I needed to know what db column and types my db tables have.

I found that in your metadata under paths/TABLENAME/post/parameters[0]/schema/properties
all db columns could be found.. and that all types are set to "string"

In order to get the db-types aswel I edited your class and added "db-type" to
paths/TABLENAME/get/responses/200/schema/items/properties/PROPERTYNAME
```js
{
   properties: {
      birthday: {
         db-type: "date",
         type:"string"
      },
     ......
   }
}
````

So now I can what what the column types are in the db, and so for my model I could convert a db column date to a js Date() object and viseversa.


note: I only added the query reflect_type to the MySQL class, I don't have the experience to write it also in PostgreSQL, SQLServer, SQLite.

hit me back what you think of it, and if maybe you are willing to accept the pull request or have a better solution, please let me know.

Barry