### PR TITLE
Adding "x-dbtype" to show database field type

### DIFF
--- a/api.php
+++ b/api.php
@@ -88,7 +88,15 @@ class MySQL implements DatabaseInterface {
 					k2."REFERENCED_TABLE_SCHEMA" = ? AND
 					k1."TABLE_NAME" COLLATE \'utf8_bin\' = k2."TABLE_NAME" COLLATE \'utf8_bin\' AND
 					k1."REFERENCED_TABLE_NAME" COLLATE \'utf8_bin\' = ? AND
-					k2."REFERENCED_TABLE_NAME" COLLATE \'utf8_bin\' IN ?'
+					k2."REFERENCED_TABLE_NAME" COLLATE \'utf8_bin\' IN ?',
+			'reflect_type'=> 'SELECT
+					"COLUMN_NAME", "COLUMN_TYPE"
+				FROM
+					"INFORMATION_SCHEMA"."COLUMNS"
+				WHERE
+					"TABLE_SCHEMA" = ? AND
+					"TABLE_NAME" = ?
+			'
 		);
 	}
 
@@ -2216,6 +2224,11 @@ class PHP_CRUD_API {
 				$primaryKeys = $this->findPrimaryKeys($table_list[0],$database);
 				foreach ($primaryKeys as $primaryKey) {
 					$table_fields[$table['name']][$primaryKey]->primaryKey = true;
+				}
+				$result = $this->db->query($this->db->getSql('reflect_type'),array($database,$table_list[0]));
+				while ($row = $this->db->fetchRow($result)) {
+					$expl = explode('(',$row[1]);
+					$table_fields[$table['name']][$row[0]]->type = $expl[0];
 				}
 			}
 

--- a/api.php
+++ b/api.php
@@ -2341,6 +2341,9 @@ class PHP_CRUD_API {
 							if ($k>0) echo ',';
 							echo '"'.$field.'": {';
 							echo '"type": "string"';
+							if (isset($action['fields'][$field]->type)) {
+								echo ',"x-dbtype": '.json_encode($action['fields'][$field]->type);
+							}
 							if (isset($action['fields'][$field]->referenced)) {
 								echo ',"x-referenced": '.json_encode($action['fields'][$field]->referenced);
 							}
@@ -2371,6 +2374,9 @@ class PHP_CRUD_API {
 							if ($k>0) echo ',';
 							echo '"'.$field.'": {';
 							echo '"type": "string"';
+							if (isset($action['fields'][$field]->type)) {
+								echo ',"x-dbtype": '.json_encode($action['fields'][$field]->type);
+							}
 							if (isset($action['fields'][$field]->referenced)) {
 								echo ',"x-referenced": '.json_encode($action['fields'][$field]->referenced);
 							}
@@ -2427,6 +2433,9 @@ class PHP_CRUD_API {
 							if ($k>0) echo ',';
 							echo '"'.$field.'": {';
 							echo '"type": "string"';
+							if (isset($action['fields'][$field]->type)) {
+								echo ',"x-dbtype": '.json_encode($action['fields'][$field]->type);
+							}
 							if (isset($action['fields'][$field]->referenced)) {
 								echo ',"x-referenced": '.json_encode($action['fields'][$field]->referenced);
 							}
@@ -2454,6 +2463,9 @@ class PHP_CRUD_API {
 							if ($k>0) echo ',';
 							echo '"'.$field.'": {';
 							echo '"type": "string"';
+							if (isset($action['fields'][$field]->type)) {
+								echo ',"x-dbtype": '.json_encode($action['fields'][$field]->type);
+							}
 							if (isset($action['fields'][$field]->referenced)) {
 								echo ',"x-referenced": '.json_encode($action['fields'][$field]->referenced);
 							}


### PR DESCRIPTION
@VyseExhale : This is similar to your pull request.  There are other places to add the x-dbtype.  The reflect_type entry translates the MySQL numeric types to actual types.  For now, the other db's will have to tweak the code to provide the full type translation (IE: SqlServer will show numbers for x-dbtype).   Since we are just including an x-dbtype, this does not really impact the swagger 2.0 standard at the moment.    I tested this against the MySQL test database and resultant json at swagger.io.   It is fine.   The unit tests for sqlite, postgresql and mysql pass.

It is a step in the right direction I think.  Note the icon is really a binary data blob instead of a string.   In actuality, I believe you deliver it as a string translated to hex?

>                 icon:
>                 type: string
>                 x-dbtype: blob


> Running tests with phpunit-5.7
> PHP 7.0.15 (cli) (built: Jan 18 2017 11:21:05) ( NTS )
> Copyright (c) 1997-2017 The PHP Group
> Zend Engine v3.0.0, Copyright (c) 1998-2017 Zend Technologies
> ---
> SQLlite
> PHPUnit 5.7.13 by Sebastian Bergmann and contributors.
> 
> ................................................................. 65 / 73 ( 89%)
> ........                                                          73 / 73 (100%)
> 
> Time: 1.11 seconds, Memory: 10.00MB
> 
> OK (73 tests, 107 assertions)
> ---
> MySQL
> PHPUnit 5.7.13 by Sebastian Bergmann and contributors.
> 
> ................................................................. 65 / 73 ( 89%)
> ........                                                          73 / 73 (100%)
> 
> Time: 4.25 seconds, Memory: 10.00MB
> 
> OK (73 tests, 108 assertions)
> ---
> PostgreSQL
> PHPUnit 5.7.13 by Sebastian Bergmann and contributors.
> 
> ................................................................. 65 / 73 ( 89%)
> ........                                                          73 / 73 (100%)
> 
> Time: 1.33 seconds, Memory: 10.00MB
> 
> OK (73 tests, 108 assertions)