### PR TITLE
Allowing json, jsonb in postgres

### DIFF
--- a/api.php
+++ b/api.php
@@ -471,7 +471,7 @@ class PostgreSQL implements DatabaseInterface {
 	}
 
 	public function isJsonType($field) {
-		return $field->type == 'jsonb';
+        return in_array($field->type,array('json','jsonb'));
 	}
 
 	public function getDefaultCharset() {
@@ -1075,11 +1075,11 @@ class SQLite implements DatabaseInterface {
 	}
 
 	public function isGeometryType($field) {
-		return in_array($field->type,array('geometry'));;
+		return in_array($field->type,array('geometry'));
 	}
 
 	public function isJsonType($field) {
-		return in_array($field->type,array('json','jsonb'));;
+		return in_array($field->type,array('json','jsonb'));
 	}
 
 	public function getDefaultCharset() {


### PR DESCRIPTION
This addresses my first report in #190. I ran the test suite, and things are still working fine with Postgres.

I stopped short of implementing the XML field type in Postgres as I think that will be a significant enough change to warrant its own PR.

I did not add another test for this as it's a pretty minimal semantic change, but I can do so if you think it's necessary.

Thanks for you consideration!