### PR TITLE
A little bugfix.

### DIFF
--- a/api.php
+++ b/api.php
@@ -2429,7 +2429,10 @@ class PHP_CRUD_API {
 						echo '"required":true,';
 						echo '"schema":{';
 						echo '"type": "object",';
-						echo '"required":'.json_encode(array_keys(array_filter($action['fields'],function($f){ return $f->required; }))).',';
+                                                $required_fields = array_keys(array_filter($action['fields'],function($f){ return $f->required; }));
+                                                if (count($required_fields) > 0) {
+                                                        echo '"required":'.json_encode($required_fields).',';
+                                                }
 						echo '"properties": {';
 						foreach (array_keys($action['fields']) as $k=>$field) {
 							if ($k>0) echo ',';
@@ -2497,7 +2500,10 @@ class PHP_CRUD_API {
 						echo '"required":true,';
 						echo '"schema":{';
 						echo '"type": "object",';
-						echo '"required":'.json_encode(array_keys(array_filter($action['fields'],function($f){ return $f->required; }))).',';
+                                                $required_fields = array_keys(array_filter($action['fields'],function($f){ return $f->required; }));
+                                                if (count($required_fields) > 0) {
+                                                        echo '"required":'.json_encode($required_fields).',';
+                                                }
 						echo '"properties": {';
 						foreach (array_keys($action['fields']) as $k=>$field) {
 							if ($k>0) echo ',';

--- a/tests/tests.php
+++ b/tests/tests.php
@@ -450,7 +450,7 @@ class PHP_CRUD_API_Test extends PHPUnit_Framework_TestCase
 	{
 		$test = new API($this);
 		$test->options('/posts/2');
-		$test->expect('["Access-Control-Allow-Headers: Content-Type, X-XSRF-Token","Access-Control-Allow-Methods: OPTIONS, GET, PUT, POST, DELETE, PATCH","Access-Control-Allow-Credentials: true","Access-Control-Max-Age: 1728000"]',false);
+		$test->expect('["Access-Control-Allow-Headers: Content-Type, X-XSRF-TOKEN","Access-Control-Allow-Methods: OPTIONS, GET, PUT, POST, DELETE, PATCH","Access-Control-Allow-Credentials: true","Access-Control-Max-Age: 1728000"]',false);
 	}
 
 	public function testHidingPasswordColumn()


### PR DESCRIPTION
Fix for schema object.  If no fields are required, do not add required tag. 

Depending on the database you were testing, you might have ended up with valid schema.  In issue #193, this bug is triggered when a table has no required fields.  

The required parameter in the schema: section would result in:

`required: []`

which is invalid for the swagger editor.   The code update checks for at least one or more fields that are required before printing out an array.

I looked for an explanation in the swagger specification (twice) and could not find it.  Ok.  It is part of the JSON Schema Validation specification (https://tools.ietf.org/html/draft-fge-json-schema-validation-00)

```
5.4.3.  required

5.4.3.1.  Valid values

   The value of this keyword MUST be an array.  This array MUST have at
   least one element.  Elements of this array MUST be strings, and MUST
   be unique.
```

Fix to test suite (Token->TOKEN).

Test suite for sqlite, mysql and postgresql pass with this fix.