### PR TITLE
Add apiKey support for query and header methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,8 @@ $api = new PHP_CRUD_API(array(
 	'get'=>$_GET,
 	'post'=>file_get_contents('php://input'),
 	'origin'=>$_SERVER['HTTP_ORIGIN'],
+// Use to pass security PHP object from PHP_API_AUTH to PHP_CRUD_API
+	'security'=>null,
 ));
 $api->executeCommand();
 ```

--- a/api.php
+++ b/api.php
@@ -2116,6 +2116,7 @@ class PHP_CRUD_API {
 		$get = isset($get)?$get:null;
 		$post = isset($post)?$post:null;
 		$origin = isset($origin)?$origin:null;
+		$security = isset($security)?$security:null;
 
 		// defaults
 		if (!$dbengine) {
@@ -2160,7 +2161,7 @@ class PHP_CRUD_API {
 		}
 
 		$this->db = $db;
-		$this->settings = compact('method', 'request', 'get', 'post', 'origin', 'database', 'table_authorizer', 'record_filter', 'column_authorizer', 'tenancy_function', 'input_sanitizer', 'input_validator', 'auto_include', 'allow_origin');
+		$this->settings = compact('method', 'request', 'get', 'post', 'origin', 'database', 'table_authorizer', 'record_filter', 'column_authorizer', 'tenancy_function', 'input_sanitizer', 'input_validator', 'auto_include', 'allow_origin','security');
 	}
 
 	public static function php_crud_api_transform(&$tables) {
@@ -2297,6 +2298,9 @@ class PHP_CRUD_API {
 		echo '},';
 		echo '"host":"'.$_SERVER['HTTP_HOST'].'",';
 		echo '"basePath":"'.$_SERVER['SCRIPT_NAME'].'",';
+		if ($settings['security']!==null) {
+			$settings['security']->swagger();
+		}
 		echo '"schemes":["http'.((!empty($_SERVER['HTTPS'])&&$_SERVER['HTTPS']!=='off')?'s':'').'"],';
 		echo '"consumes":["application/json"],';
 		echo '"produces":["application/json"],';
@@ -2429,10 +2433,10 @@ class PHP_CRUD_API {
 						echo '"required":true,';
 						echo '"schema":{';
 						echo '"type": "object",';
-                                                $required_fields = array_keys(array_filter($action['fields'],function($f){ return $f->required; }));
-                                                if (count($required_fields) > 0) {
-                                                        echo '"required":'.json_encode($required_fields).',';
-                                                }
+						$required_fields = array_keys(array_filter($action['fields'],function($f){ return $f->required; }));
+						if (count($required_fields) > 0) {
+							echo '"required":'.json_encode($required_fields).',';
+						}
 						echo '"properties": {';
 						foreach (array_keys($action['fields']) as $k=>$field) {
 							if ($k>0) echo ',';
@@ -2500,10 +2504,10 @@ class PHP_CRUD_API {
 						echo '"required":true,';
 						echo '"schema":{';
 						echo '"type": "object",';
-                                                $required_fields = array_keys(array_filter($action['fields'],function($f){ return $f->required; }));
-                                                if (count($required_fields) > 0) {
-                                                        echo '"required":'.json_encode($required_fields).',';
-                                                }
+						$required_fields = array_keys(array_filter($action['fields'],function($f){ return $f->required; }));
+						if (count($required_fields) > 0) {
+							echo '"required":'.json_encode($required_fields).',';
+						}
 						echo '"properties": {';
 						foreach (array_keys($action['fields']) as $k=>$field) {
 							if ($k>0) echo ',';
@@ -2588,8 +2592,8 @@ class PHP_CRUD_API {
 				echo '}';
 			}
 		}
-		echo '}';
-			echo '}';
+		echo '}'; //paths
+	echo '}'; // end swagger definition
 	}
 
 	protected function allowOrigin($origin,$allowOrigins) {
@@ -2648,6 +2652,16 @@ class PHP_CRUD_API {
 //	header('HTTP/1.0 401 Unauthorized');
 //	exit(0);
 // }
+//
+// Pass the $auth variable into PHP_CRUD_API as needed to add appropriate security information to
+// Swagger defintion.  See PHP_API_AUTH for more information.
+//
+// $api = new PHP_CRUD_API(array(
+//      ....
+// 	'security'=>$auth,
+// 	....
+// ));
+// $api->executeCommand();
 
 // uncomment the lines below when running in stand-alone mode:
 


### PR DESCRIPTION
Issue #197.  This adds a little bit of code to allow for an expanded swagger definition if you add an apiKey to PHP_API_AUTH.   If this part of security is not used, it should have no impact on the operation.  Both query and header methods of apiKey do work via the swagger.io editor with at least Chrome.   More fine grained control can be added later.

This also fixes some whitespace issues on a previous pull request.  Added comments on some closing braces.
