### PR TITLE
Swagger: Output swagger description

### DIFF
--- a/api.php
+++ b/api.php
@@ -2628,7 +2628,8 @@ class PHP_CRUD_API {
 		if ($this->settings['origin']) {
 			$this->allowOrigin($this->settings['origin'],$this->settings['allow_origin']);
 		}
-		if (!$this->settings['request']) {
+		$currentScriptFilename = basename(__FILE__);
+		if (!$this->settings['request'] || $this->settings['request'] == $currentScriptFilename) {
 			$this->swagger($this->settings);
 		} else {
 			$parameters = $this->getParameters($this->settings);


### PR DESCRIPTION
Currently the swagger description is no longer outputted by requesting the url `http://example.com/api.php`. This behavior affects for example the project `php-crud-ui`.

This commit is a fix, that the swagger description is outputted the when scriptfile api.php is requested without any given entity/subject. 

I've decided not to implement that change in the constructor `__construct()` where the request param is filled. Maybe later you want to access the full unmodified request/path info string and therefore I've extended the method `executeCommand()`.

In my current development environment I have no possiblity to extend and run your phpunit test cases. This can be a task for the future to compare the output of a request of the api.php root (/) for containing some swagger information.