### PR TITLE
Bugfix multiple soft deletes (beforeHandler)

### DIFF
--- a/api.php
+++ b/api.php
@@ -1137,10 +1137,12 @@ class PHP_CRUD_API {
 	protected function applyBeforeHandler(&$action,&$database,&$table,&$ids,&$callback,&$inputs) {
 		if (is_callable($callback,true)) {
 			$max = count($ids)?:count($inputs);
+			$origaction = $action;
 			for ($i=0;$i<$max;$i++) {
+				$action = $origaction;
 				if (!isset($ids[$i])) $ids[$i] = false;
 				if (!isset($inputs[$i])) $inputs[$i] = false;
-				$callback($action,$database,$table,$id,$inputs[$i]);
+				$callback($action,$database,$table,$ids[$i],$inputs[$i]);
 			}
 		}
 	}
@@ -1885,10 +1887,6 @@ class PHP_CRUD_API {
 
 		// input
 		$inputs = $this->retrieveInputs($post);
-		if ($before) {
-			$this->applyBeforeHandler($action,$database,$tables[0],$key[0],$before,$inputs);
-		}
-		
 		foreach ($inputs as $k=>$context) {
 			$input = $this->filterInputByFields($context,$fields[$tables[0]]);
 
@@ -1898,6 +1896,10 @@ class PHP_CRUD_API {
 
 			$this->convertInputs($input,$fields[$tables[0]]);
 			$inputs[$k] = $input;
+		}
+
+		if ($before) {
+			$this->applyBeforeHandler($action,$database,$tables[0],$key[0],$before,$inputs);
 		}
 
 		return compact('action','database','tables','key','page','filters','fields','orderings','transform','inputs','collect','select','before','after');


### PR DESCRIPTION
Following our conversation [210](https://github.com/mevdschee/php-crud-api/pull/210) there are now 3 issues doing a soft delete :

The first issue is in the "applyBeforeHandler":
```php
$callback($action,$database,$table,$id,$inputs[$i]);
```
$id shoud be $ids[$i], you've probably missed that one :
```php
$callback($action,$database,$table,$ids[$i],$inputs[$i]);
```

The second issue will rise if you do 2 or more (soft)deletes: Like
```php
DELETE http://localhost/api.php/categories/1,2
```
In the second [loop](https://github.com/mevdschee/php-crud-api/blob/master/api.php#L1140-L1144) of the applyBeforeHandler, the $action is overwritten by the first loop.. so the in the second before call, the $cmd = 'update'.. so the 2nd one wil never be deleted
first:
```php
'before'=>function(&$cmd, $db, $tab, $id, &$in) { 
	$cmd;//delete
	// then we do this
	if ($cmd = 'delete') {
		$cmd = 'update'; // change command to update
		$in = (object) array('deleted'=>date('Y-m-d H:i:s', time()));
	}
}
```
In the second call cmd is changed to update by the first call:
```php
'before'=>function(&$cmd, $db, $tab, $id, &$in) { 
	$cmd;//update
	// so the code below never gets executed
	if ($cmd = 'delete') {
		$cmd = 'update'; // change command to update
		$in = (object) array('deleted'=>date('Y-m-d H:i:s', time()));
	}
}
```
I fixed this by storing the $action in a temp variable $origaction; and reset the $action in every start of the loop
```php
protected function applyBeforeHandler(&$action,&$database,&$table,&$ids,&$callback,&$inputs) {
	if (is_callable($callback,true)) {
		$max = count($ids)?:count($inputs);
		$origaction = $action;
		for ($i=0;$i<$max;$i++) {
			$action = $origaction;
			if (!isset($ids[$i])) $ids[$i] = false;
			if (!isset($inputs[$i])) $inputs[$i] = false;
			$callback($action,$database,$table,$ids[$i],$inputs[$i]);
		}
	}
}
```

Then the last error, which I allready pointed out before.
The call to the [applyBeforeHandler](https://github.com/mevdschee/php-crud-api/blob/master/api.php#L1888-L1890) should be placed AFTER the [foreach](https://github.com/mevdschee/php-crud-api/blob/master/api.php#L1892-L1901)
Right now the [filterInputByFields ](https://github.com/mevdschee/php-crud-api/blob/master/api.php#L1893) filteres out the "delete" column which I just inserted in my "before" statement.
We may presume that the backend dev knows the consequences of his action by changing the input, so there's no need to call the  applyInputSanitizer, applyInputValidator after the applyBeforeHandler is called.
So we need to change [this](https://github.com/mevdschee/php-crud-api/blob/master/api.php#L1888-L1901) to:
```php
foreach ($inputs as $k=>$context) {
	$input = $this->filterInputByFields($context,$fields[$tables[0]]);

	if ($tenancy_function) $this->applyInputTenancy($tenancy_function,$action,$database,$tables[0],$input,$fields[$tables[0]]);
	if ($input_sanitizer) $this->applyInputSanitizer($input_sanitizer,$action,$database,$tables[0],$input,$fields[$tables[0]]);
	if ($input_validator) $this->applyInputValidator($input_validator,$action,$database,$tables[0],$input,$fields[$tables[0]],$context);

	$this->convertInputs($input,$fields[$tables[0]]);
	$inputs[$k] = $input;
}


if ($before) {
	$this->applyBeforeHandler($action,$database,$tables[0],$key[0],$before,$inputs);
}
```

Barry