### PR TITLE
Adding travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,29 @@
+dist: trusty
+sudo: false
+
+language: php
+
+services:
+  # - mysql
+  - postgresql
+
+addons:
+  postgresql: "9.4"
+
+php:
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
+  - 7.1
+
+before_install:
+  - phpenv config-add travisphp.ini
+  - psql -c 'create database testing;' -U postgres
+  - psql -U postgres -c "create extension postgis"
+  # - mysql -e 'CREATE DATABASE testing;'
+  - cp tests/config.php.travis tests/config.php
+
+script:
+  - curl https://phar.phpunit.de/phpunit-4.8.phar -L -o phpunit.phar && chmod +x phpunit.phar
+  - php phpunit.phar

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![Average time to resolve an issue](http://isitmaintained.com/badge/resolution/mevdschee/php-crud-api.svg)](http://isitmaintained.com/project/mevdschee/php-crud-api "Average time to resolve an issue")
 [![Percentage of issues still open](http://isitmaintained.com/badge/open/mevdschee/php-crud-api.svg)](http://isitmaintained.com/project/mevdschee/php-crud-api "Percentage of issues still open")
+[![Build Status](https://travis-ci.org/mevdschee/php-crud-api.svg?branch=master)](https://travis-ci.org/mevdschee/php-crud-api)
 
 # PHP-CRUD-API
 

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,9 @@
   "require": {
     "php": ">=5.3.0"
   },
+  "require-dev": {
+    "phpunit/phpunit": "^5.7.0"
+  },
   "autoload": {
     "files": ["api.php"]
   }

--- a/tests/config.php.travis
+++ b/tests/config.php.travis
@@ -1,0 +1,39 @@
+<?php
+
+class PHP_CRUD_API_Config
+{
+    /**
+     * Configure one or more database connections as associative arrays.
+     * Tests will be run against any database connection specified here.
+     *
+     * @var array
+     */
+    public static $config = array(
+        /* MySQL is disabled because v5.7 is required for all tests to pass,
+            and Travis only has up to MySQL 5.6 installed by default. This
+            will be runnable once we have a test suite that adapts to the
+            available MySQL version. See: https://github.com/mevdschee/php-crud-api/issues/194
+        array(
+            'dbengine' => 'MySQL',
+            'hostname' => 'localhost',
+            'username' => 'root',
+            'password' => 'travis',
+            'database' => 'testing',
+        ),
+        */
+        array(
+            'dbengine' => 'PostgreSQL',
+            'hostname' => 'localhost',
+            'username' => 'postgres',
+            'password' => '',
+            'database' => 'testing',
+        ),
+        array(
+            'dbengine' => 'SQLite',
+            'hostname' => '',
+            'username' => '',
+            'password' => '',
+            'database' => 'tests/sqlite.db',
+        ),
+    );
+}

--- a/travisphp.ini
+++ b/travisphp.ini
@@ -1,0 +1,4 @@
+mysql.default_socket = "/run/mysql-5.6/mysqld.sock"
+mysqli.default_socket = "/run/mysql-5.6/mysqld.sock"
+pdo_mysql.default_socket = "/run/mysql-5.6/mysqld.sock"
+error_reporting = E_ALL & ~E_STRICT & ~E_NOTICE & ~E_DEPRECATED


### PR DESCRIPTION
Addresses #226 

This adds configuration to let Travis automatically run our tests every time we make updates. Whoo!

I currently have it set up to run on my fork of this repo: https://travis-ci.org/karllhughes/php-crud-api

You will need to create an account on Travis and add the main repository. Once added, you should be able to set it to auto-run tests when PRs are made.

There are some known deficiencies in this PR. I'm going to open an issue to deal with them later. I figured it would be better to have half our tests automatically running than to have none of them!