### PR TITLE
Removing DBs as services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,6 @@ sudo: false
 
 language: php
 
-services:
-  #- mysql
-  #- postgresql
-
 addons:
   postgresql: "9.4"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: true
 
 language: php
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: trusty
-sudo: true
+sudo: false
 
 language: php
 
 services:
-  - mysql
+  #- mysql
   - postgresql
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: php
 
 services:
   #- mysql
-  - postgresql
+  #- postgresql
 
 addons:
   postgresql: "9.4"


### PR DESCRIPTION
To address this comment: https://github.com/mevdschee/php-crud-api/issues/238#issuecomment-294307121

Apparently Travis already installs MySQL and Postgres is in the add-ons section, so these two lines were unnecessary. They were causing that warning message in Travis.

More to come on improving the Travis later.