### PR TITLE
Use PHPUnit\Framework\TestCase instead of PHPUnit_Framework_TestCase

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "php": ">=5.3.0"
   },
   "require-dev": {
-    "phpunit/phpunit": "^4.8.0"
+    "phpunit/phpunit": "^4.8.35"
   },
   "autoload": {
     "files": ["api.php"]

--- a/tests/TestBase.php
+++ b/tests/TestBase.php
@@ -1,7 +1,9 @@
 <?php
 namespace Mevdschee\PhpCrudApi\Tests;
 
-abstract class TestBase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase;
+
+abstract class TestBase extends TestCase
 {
     public static function setUpBeforeClass()
     {


### PR DESCRIPTION
I use the `PHPUnit\Framework\TestCase` notation instead of `PHPUnit_Framework_TestCase` while extending our TestCase. This will help us migrate to PHPUnit 6, that [no longer support snake case class names](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-6.0.md#changed-1).

I just need to bump PHPUnit version to [`^4.8.35`](https://github.com/sebastianbergmann/phpunit/blob/master/ChangeLog-4.8.md#4835---2017-02-06), that support this namespace.