### PR TITLE
Handle leading whitespace in JSON body

### DIFF
--- a/api.php
+++ b/api.php
@@ -1679,6 +1679,7 @@ class PHP_CRUD_API {
 	}
 
 	protected function retrieveInputs($data) {
+		$data = trim($data, " \t\n\r");
 		if (strlen($data)==0) {
 			$input = false;
 		} else if ($data[0]=='{' || $data[0]=='[') {

--- a/tests/Tests.php
+++ b/tests/Tests.php
@@ -643,4 +643,14 @@ abstract class Tests extends TestBase
         $test->get('/posts/1');
         $test->expect('{"id":1,"user_id":1,"category_id":1,"content":"blog start\'d"}');
     }
+
+    public function testAddPostWithLeadingWhitespaceInJSON()
+    {
+        $test = new Api($this);
+        $test->post('/posts', '      
+                    {"user_id":1,"category_id":1,"content":"test whitespace"}   ');
+        $test->expect('21');
+        $test->get('/posts/21');
+        $test->expect('{"id":21,"user_id":1,"category_id":1,"content":"test whitespace"}');
+    }
 }


### PR DESCRIPTION
Issue:
When sending JSON in the body of a POST
request from an HTML form - for creating
a new record, a new record was being created,
but with null as the value for all the fields,
instead of the values supplied.

Cause:
The template text in the textarea field, in the
HTML form had some leading whitespace. On looking
through the source, json_decode is being called
only if the first character of the $data variable
is a '{' or a '['.

JSON Specification RFC4627
https://tools.ietf.org/html/rfc4627#section-2

says that insignificant
whitespace is allowed before or after any of the
six structural characters - '{','[',']','}',':',','

where whitespace is defined as:
ws = *(
                %x20 /              ; Space
                %x09 /              ; Horizontal tab
                %x0A /              ; Line feed or New line
                %x0D                ; Carriage return
            )

Fix:
trim the above characters from the beginning and ending
of the received data before checking that the first
character is a '[' or '{'