### PR TITLE
Correct 400 response to malformed json in POST

### DIFF
--- a/api.php
+++ b/api.php
@@ -1270,6 +1270,15 @@ class PHP_CRUD_API {
 		}
 	}
 
+	protected function exitWith400($type) {
+		if (isset($_SERVER['REQUEST_METHOD'])) {
+			header('Content-Type:',true,400);
+			die("The request could not be understood by the server due to malformed syntax. The client SHOULD NOT repeat the request without modifications. ($type)");
+		} else {
+			throw new \Exception("Bad request ($type)");
+		}
+	}
+
 	protected function exitWith422($object) {
 		if (isset($_SERVER['REQUEST_METHOD'])) {
 			header('Content-Type:',true,422);
@@ -1684,6 +1693,11 @@ class PHP_CRUD_API {
 			$input = false;
 		} else if ($data[0]=='{' || $data[0]=='[') {
 			$input = json_decode($data);
+			$causeCode = json_last_error();
+			if ($causeCode !== JSON_ERROR_NONE) {
+				$errorString = "Error decoding input JSON. json_last_error code: " . $causeCode;
+				$this->exitWith400($errorString);
+			}
 		} else {
 			parse_str($data, $input);
 			foreach ($input as $key => $value) {

--- a/tests/Api.php
+++ b/tests/Api.php
@@ -138,4 +138,22 @@ class Api
         }
         return $this;
     }
+
+    public function expectPattern($expectedOutputPattern, $expectedErrorPattern) {
+        $exception = false;
+        ob_start();
+        try {
+            $this->api->executeCommand();
+        } catch (\Exception $e) {
+            $exception = $e->getMessage();
+        }
+        $outputData = ob_get_contents();
+        ob_end_clean();
+        if ($exception) {
+            $this->test->assertRegExp($expectedErrorPattern, $exception);
+        } else {
+            $this->test->assertRegExp($expectedOutputPattern, $outputData);
+        }
+        return $this;
+    }
 }

--- a/tests/Tests.php
+++ b/tests/Tests.php
@@ -290,7 +290,7 @@ abstract class Tests extends TestBase
     {
         $test = new Api($this);
         $test->post('/posts', '{"}');
-        $test->expect(false, 'Not found (input)');
+        $test->expectPattern(false, '/^Bad request.*$/');
     }
 
     public function testErrorOnDuplicatePrimaryKey()


### PR DESCRIPTION
Symptom:
----------
Trying to create an object sending a seemingly correct JSON request in a
POST message - was giving a 404 not found error.  When looking at the cause
in the browser devtools - the body of the response contained "Not found (input)"

Cause:
-------
We were trying to validate parameters - even when the POST body
contained invalid JSON.  

We call json_decode($data) in retrieveInputs - but, do not check for errors.
The JSON request was malformed and it had omitted the double quotes.
example: { fieldName : "fieldValue" }

Expected behavior and fix:
---------------------------
A POST request with malformed JSON should get a 400 "bad request"
response. Even more helpful would be an error code indicating why the
JSON was bad.

If we call json_decode(), afterwards, [we immediately call
json_last_error()](http://php.net/manual/en/function.json-last-error.php), and[ if the return value does not match
JSON_ERROR_NONE](http://php.net/manual/en/function.json-decode.php#110820), we send it across bundled in a 400 response, so that
the user may rectify the cause by looking at the exact error message.

The possible error messages right now are:

    CODE  CONSTANT-ERROR MESSAGE

    0     JSON_ERROR_NONE-No error has occurred
    1     JSON_ERROR_DEPTH-The maximum stack depth has been exceeded
    2     JSON_ERROR_STATE_MISMATCH-Invalid or malformed JSON
    3     JSON_ERROR_CTRL_CHAR-Control character error, possibly incorrectly encoded
    4     JSON_ERROR_SYNTAX-Syntax error
    5     JSON_ERROR_UTF8-Malformed UTF-8 characters, possibly incorrectly encoded
    6     JSON_ERROR_RECURSION-One or more recursive references in the value to be encoded
    7     JSON_ERROR_INF_OR_NAN-One or more NAN or INF values in the value to be encoded
    8     JSON_ERROR_UNSUPPORTED_TYPE-A value of a type that cannot be encoded was given
    9     JSON_ERROR_INVALID_PROPERTY_NAME-A property name that cannot be encoded was given
    10    JSON_ERROR_UTF16-Malformed UTF-16 characters, possibly incorrectly encoded

After the fix:
-------------
On malformed JSON in the POST body - now the following is returned:
```
    The request could not be understood by the server due to malformed
    syntax. The client SHOULD NOT repeat the request without modifications.
    (Error decoding input JSON. json_last_error code: 4)
```

If REQUEST_METHOD is not set - we throw an exception that says something
like:
```
    'Bad request (Error decoding input JSON. json_last_error code: 4)'
```
In order to accommodate this change in behavior - in the test suite, we
need a new method expectPattern (as the error code in the end of the
string may change, but the starting pattern stays the same -
``` 
(/^Bad request.*$/)
```