### PR TITLE
Use utf8mb4 instead of utf8 in commented-out starter code

### DIFF
--- a/api.php
+++ b/api.php
@@ -2719,7 +2719,7 @@ class PHP_CRUD_API {
 // 	'username'=>'',
 // 	'password'=>'',
 // 	'database'=>'',
-// 	'charset'=>'utf8'
+// 	'charset'=>'utf8mb4'
 // ));
 // $api->executeCommand();
 


### PR DESCRIPTION
'utf8' in mySQL is actually a 3-byte encoding that cannot encode characters that occupy 4 bytes in UTF-8. 'utf8mb4' is a saner default.