### PR TITLE
Check if key is false before adding as filter, fix #337

### DIFF
--- a/api.php
+++ b/api.php
@@ -1543,7 +1543,7 @@ class PHP_CRUD_API {
 			$params[] = $k;
 			$params[] = $v;
 		}
-		$this->addFilter($filters,$table,'and',$key[1],'eq',$key[0][0]);
+		if ($key) $this->addFilter($filters,$table,'and',$key[1],'eq',$key[0][0]);
 		$this->addWhereFromFilters($filters[$table],$sql,$params);
 		$result = $this->db->query($sql,$params);
 		if (!$result) return null;

--- a/tests/Tests.php
+++ b/tests/Tests.php
@@ -653,4 +653,14 @@ abstract class Tests extends TestBase
         $test->get('/posts/21');
         $test->expect('{"id":21,"user_id":1,"category_id":1,"content":"test whitespace"}');
     }
+
+    public function testEditPostWithFilters(){
+        $test = new Api($this);
+        $test->post('/posts?filter[]=user_id,eq,1&filter[]=category_id,eq,1&transform=1', '
+                    {"content":"Post Updated with new value"}');
+        $test->expect('1');
+        $test->get('/posts/1');
+        $test->expect('{"id":1,"user_id":1,"category_id":1,"content":"Post Updated with new value"}');
+    }
 }
+

--- a/tests/Tests.php
+++ b/tests/Tests.php
@@ -656,7 +656,7 @@ abstract class Tests extends TestBase
 
     public function testEditPostWithFilters(){
         $test = new Api($this);
-        $test->post('/posts?filter[]=user_id,eq,1&filter[]=category_id,eq,1&transform=1', '
+        $test->put('/posts?filter[]=user_id,eq,1&filter[]=category_id,eq,1&transform=1', '
                     {"content":"Post Updated with new value"}');
         $test->expect('1');
         $test->get('/posts/1');


### PR DESCRIPTION
Upon checking to see where the script is failing, it seems as though
once all the parameters have been sucessfully been parsed, and the
update command is issued, the function once again tries to add a
filter using the key variable, however as none are provided, a null
filter is added, and thus stopping the script to correctly identify
the row/s to be modified.