### PR TITLE
Escape control-characters in generated swagger

### DIFF
--- a/api.php
+++ b/api.php
@@ -2367,7 +2367,7 @@ class PHP_CRUD_API {
 			if ($i>0) echo ',';
 			echo '{';
 			echo '"name":"'.$table['name'].'",';
-			echo '"description":"'.$table['comments'].'"';
+			echo '"description":'.json_encode($table['comments']);
 			echo '}';
 		}
 		echo '],';


### PR DESCRIPTION
When some table's description has `control-characters`, likes
`\t` `\n`,
swagger that generated by `/api.php` is a defective json