### PR TITLE
Fix nginx config for api.php/ (with trailing slash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -877,7 +877,7 @@ server {
     }
 
     location ~ [^/]\.php(/|$) {
-        fastcgi_split_path_info ^(.+\.php)(/.+)$;
+        fastcgi_split_path_info ^(.+\.php)(/.*)$;
         try_files $fastcgi_script_name =404;
         set $path_info $fastcgi_path_info;
         fastcgi_param PATH_INFO $path_info;


### PR DESCRIPTION
The Vue file calls to `api.php/` with trailing slash, the given config returns a nginx-404 on that.