### PR TITLE
Add custom endpoints

### DIFF
--- a/src/Tqdev/PhpCrudApi/Api.php
+++ b/src/Tqdev/PhpCrudApi/Api.php
@@ -119,6 +119,16 @@ class Api implements RequestHandlerInterface
                     $geoJson = new GeoJsonService($reflection, $records);
                     new GeoJsonController($router, $responder, $geoJson);
                     break;
+                default:
+                    $controllerChunks = explode(':', $controller);
+                    if (count($controllerChunks) === 2 && $controllerChunks[0] === 'custom') {
+                        $className = $controllerChunks[1];
+                        if (class_exists($className)) {
+                            $records = new RecordService($db, $reflection);
+                            new $className($router, $responder, $records);
+                        }
+                    }
+                    break;
             }
         }
         $this->router = $router;

--- a/src/Tqdev/PhpCrudApi/Controller/CustomController.php
+++ b/src/Tqdev/PhpCrudApi/Controller/CustomController.php
@@ -1,0 +1,23 @@
+<?php
+namespace Tqdev\PhpCrudApi\Controller;
+
+use Tqdev\PhpCrudApi\Middleware\Router\Router;
+use Tqdev\PhpCrudApi\Record\RecordService;
+
+abstract class CustomController
+{
+    protected $service;
+    protected $responder;
+
+    public function __construct(Router $router, Responder $responder, RecordService $service)
+    {
+        $this->registerRoutes($router);
+
+        $this->service = $service;
+        $this->responder = $responder;
+    }
+
+    protected function registerRoutes(Router $router)
+    {
+    }
+}


### PR DESCRIPTION
Hi there, me again :grin:

I find your project very flexible but I missed just one feature: custom endpoints.

I made a very few changes to allow the adding of custom endpoints very easily. It can be done by following a few simple steps.

First, create a controller for your endpoint, like this one:

```php
<?php

namespace MyNamespace; // optional

use Psr\Http\Message\ResponseInterface;
use Psr\Http\Message\ServerRequestInterface;
use Tqdev\PhpCrudApi\Controller\CustomController;
use Tqdev\PhpCrudApi\Middleware\Router\Router;


class MyCustomController extends CustomController
{
    protected function registerRoutes(Router $router)
    {
        $router->register('POST', '/custom/endpoint', [$this, 'customEndpoint']);
    }

    public function customEndpoint(ServerRequestInterface $request): ResponseInterface
    {
        // Insert logic for this endpoint

        return $this->responder->success(1);
    }
}
```

The most important for this controller is that it should extends `CustomController`. 

Then, the only thing left is to register this controller in the config:

```php
$config = new Config([
    'username' => 'xxx',
    'password' => 'xxx',
    'database' => 'xxx',
    'controllers' => 'records,openapi,custom:\\MyNamespace\\MyCustomController ',
]);
```

Tell me what you think!