### PR TITLE
Fix for pkName and openapi specs

### DIFF
--- a/api.php
+++ b/api.php
@@ -8616,7 +8616,7 @@ namespace Tqdev\PhpCrudApi\OpenApi {
                         $parameters = ['filter', 'include', 'exclude', 'order', 'size', 'page', 'join'];
                     }
                 } else {
-                    $path = sprintf('/records/%s/{%s}', $tableName, $pkName);
+                    $path = sprintf('/records/%s/{%s}', $tableName, 'id'); // $pkName);
                     if ($operation == 'read') {
                         $parameters = ['pk', 'include', 'exclude', 'join'];
                     } else {

--- a/api.php
+++ b/api.php
@@ -8322,6 +8322,7 @@ namespace Tqdev\PhpCrudApi\OpenApi {
                         $this->openapi->set("paths|$path|$method|requestBody|\$ref", "#/components/requestBodies/$operationType");
                     }
                     $this->openapi->set("paths|$path|$method|tags|0", "$type");
+                    $this->openapi->set("paths|$path|$method|operationId", "$operation"."_"."$type");
                     if ($operationType == 'updateTable') {
                         $this->openapi->set("paths|$path|$method|description", "rename table");
                     } else {
@@ -8630,6 +8631,7 @@ namespace Tqdev\PhpCrudApi\OpenApi {
                     $this->openapi->set("paths|$path|$method|requestBody|\$ref", "#/components/requestBodies/$operation-" . rawurlencode($tableName));
                 }
                 $this->openapi->set("paths|$path|$method|tags|0", "$tableName");
+                $this->openapi->set("paths|$path|$method|operationId", "$operation"."_"."$tableName");
                 $this->openapi->set("paths|$path|$method|description", "$operation $tableName");
                 switch ($operation) {
                     case 'list':


### PR DESCRIPTION
1. if the pkName is not "id" it differs from /components/parameters. So as a workaround I would hardcode it (otherwise openapi validators are not happy)
2. openapi specs require unique operationId field