### PR TITLE
CORS headers not sent when an exception is thrown

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,6 +619,8 @@ You can enable the following middleware using the "middlewares" config parameter
 - "joinLimits": Restricts join parameters to prevent database scraping
 - "customization": Provides handlers for request and response customization
 - "xml": Translates all input and output from JSON to XML
+- "errors": Catches throwables and returns an error response instead of throwing  (enabled by default)\
+  Should always be applied after cors middleware, otherwise errors will not have CORS headers sent to the client.
 
 The "middlewares" config parameter is a comma separated list of enabled middlewares.
 You can tune the middleware behavior using middleware specific configuration parameters:

--- a/src/Tqdev/PhpCrudApi/Api.php
+++ b/src/Tqdev/PhpCrudApi/Api.php
@@ -18,6 +18,7 @@ use Tqdev\PhpCrudApi\Database\GenericDB;
 use Tqdev\PhpCrudApi\GeoJson\GeoJsonService;
 use Tqdev\PhpCrudApi\Middleware\AuthorizationMiddleware;
 use Tqdev\PhpCrudApi\Middleware\BasicAuthMiddleware;
+use Tqdev\PhpCrudApi\Middleware\CatchErrorsMiddleware;
 use Tqdev\PhpCrudApi\Middleware\CorsMiddleware;
 use Tqdev\PhpCrudApi\Middleware\CustomizationMiddleware;
 use Tqdev\PhpCrudApi\Middleware\DbAuthMiddleware;
@@ -113,6 +114,9 @@ class Api implements RequestHandlerInterface
                     break;
                 case 'xml':
                     new XmlMiddleware($router, $responder, $properties, $reflection);
+                    break;
+                case 'errors':
+                    new CatchErrorsMiddleware($router, $responder, $properties, $config->getDebug());
                     break;
             }
         }
@@ -210,15 +214,6 @@ class Api implements RequestHandlerInterface
 
     public function handle(ServerRequestInterface $request): ResponseInterface
     {
-        $response = null;
-        try {
-            $response = $this->router->route($this->addParsedBody($request));
-        } catch (\Throwable $e) {
-            $response = $this->responder->error(ErrorCode::ERROR_NOT_FOUND, $e->getMessage());
-            if ($this->debug) {
-                $response = ResponseUtils::addExceptionHeaders($response, $e);
-            }
-        }
-        return $response;
+        return $this->router->route($this->addParsedBody($request));
     }
 }

--- a/src/Tqdev/PhpCrudApi/Api.php
+++ b/src/Tqdev/PhpCrudApi/Api.php
@@ -62,6 +62,7 @@ class Api implements RequestHandlerInterface
         $reflection = new ReflectionService($db, $cache, $config->getCacheTime());
         $responder = new JsonResponder();
         $router = new SimpleRouter($config->getBasePath(), $responder, $cache, $config->getCacheTime(), $config->getDebug());
+        new CatchErrorsMiddleware($router, $responder, [], $config->getDebug());
         foreach ($config->getMiddlewares() as $middleware => $properties) {
             switch ($middleware) {
                 case 'sslRedirect':

--- a/src/Tqdev/PhpCrudApi/Config.php
+++ b/src/Tqdev/PhpCrudApi/Config.php
@@ -12,7 +12,7 @@ class Config
         'password' => null,
         'database' => null,
         'tables' => '',
-        'middlewares' => 'cors',
+        'middlewares' => 'cors,errors',
         'controllers' => 'records,geojson,openapi',
         'customControllers' => '',
         'customOpenApiBuilders' => '',

--- a/src/Tqdev/PhpCrudApi/Middleware/Base/Middleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/Base/Middleware.php
@@ -19,6 +19,17 @@ abstract class Middleware implements MiddlewareInterface
         $this->properties = $properties;
     }
 
+    /**
+     * allows to load middlewares in a specific order
+     * The higher the priority, the earlier the middleware will be called
+     *
+     * @return int
+     */
+    public function getPriority() /* : int */
+    {
+        return 1;
+    }
+
     protected function getArrayProperty(string $key, string $default): array
     {
         return array_filter(array_map('trim', explode(',', $this->getProperty($key, $default))));

--- a/src/Tqdev/PhpCrudApi/Middleware/CatchErrorsMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/CatchErrorsMiddleware.php
@@ -35,4 +35,15 @@ class CatchErrorsMiddleware extends Middleware
         }
         return $response;
     }
+
+    /**
+     * High priority, should always be one of the very first middlewares to be loaded
+     * Only cors middleware should be loaded earlier
+     *
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 998;
+    }
 }

--- a/src/Tqdev/PhpCrudApi/Middleware/CatchErrorsMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/CatchErrorsMiddleware.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tqdev\PhpCrudApi\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Tqdev\PhpCrudApi\Controller\Responder;
+use Tqdev\PhpCrudApi\Middleware\Base\Middleware;
+use Tqdev\PhpCrudApi\Middleware\Router\Router;
+use Tqdev\PhpCrudApi\Record\ErrorCode;
+use Tqdev\PhpCrudApi\ResponseUtils;
+
+
+class CatchErrorsMiddleware extends Middleware
+{
+    private $debug;
+
+    public function __construct(Router $router, Responder $responder, array $properties, bool $debug)
+    {
+        parent::__construct($router, $responder, $properties);
+        $this->debug = $debug;
+    }
+
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface
+    {
+        $response = null;
+        try {
+            $response = $next->handle($request);
+        } catch (\Throwable $e) {
+            $response = $this->responder->error(ErrorCode::ERROR_NOT_FOUND, $e->getMessage());
+            if ($this->debug) {
+                $response = ResponseUtils::addExceptionHeaders($response, $e);
+            }
+        }
+        return $response;
+    }
+}

--- a/src/Tqdev/PhpCrudApi/Middleware/CorsMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/CorsMiddleware.php
@@ -66,4 +66,14 @@ class CorsMiddleware extends Middleware
         }
         return $response;
     }
+
+    /**
+     * load early in the routing stack. should be loaded before catc herrors middleware,
+     * otherwise cors headers will be missing
+     * @return int
+     */
+    public function getPriority()
+    {
+        return 999;
+    }
 }

--- a/src/Tqdev/PhpCrudApi/Middleware/Router/SimpleRouter.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/Router/SimpleRouter.php
@@ -95,6 +95,11 @@ class SimpleRouter implements Router
             $data = gzcompress(json_encode($this->routes, JSON_UNESCAPED_UNICODE));
             $this->cache->set('PathTree', $data, $this->ttl);
         }
+
+        uasort($this->middlewares, function (Middleware $a, Middleware $b) {
+            return $a->getPriority() > $b->getPriority() ? 1 : ($a->getPriority() === $b->getPriority() ? 0 : -1);
+        });
+
         return $this->handle($request);
     }
 


### PR DESCRIPTION
Replaces error handling in API@handle with a middleware that will catch
throwables. If applied after cors middleware, CORS headers will be
enabled for error messages.

Fixes #645 