### PR TITLE
Add current user endpoint to db authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -705,12 +705,13 @@ Below you find more information on each of the authentication types.
 
 #### Database authentication
 
-The database authentication middleware defines two new routes:
+The database authentication middleware defines three new routes:
 
     method path       - parameters               - description
-    ----------------------------------------------------------------------------------------
+    ---------------------------------------------------------------------------------------------------
     POST   /login     - username + password      - logs a user in by username and password
     POST   /logout    -                          - logs out the currently logged in user
+    GET    /me        -                          - returns the user as which you're currently logged in
 
 A user can be logged in by sending it's username and password to the login endpoint (in JSON format).
 The authenticated user (with all it's properties) will be stored in the `$_SESSION['user']` variable.

--- a/api.php
+++ b/api.php
@@ -7601,6 +7601,12 @@ namespace Tqdev\PhpCrudApi\Middleware {
                 }
                 return $this->responder->error(ErrorCode::AUTHENTICATION_REQUIRED, '');
             }
+            if ($method == 'GET' && $path == 'me') {
+              if (isset($_SESSION['user'])) {
+                  return $this->responder->success($_SESSION['user']);
+              }
+              return $this->responder->error(ErrorCode::AUTHENTICATION_REQUIRED, '');
+            }
             if (!isset($_SESSION['user']) || !$_SESSION['user']) {
                 $authenticationMode = $this->getProperty('mode', 'required');
                 if ($authenticationMode == 'required') {

--- a/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
@@ -85,6 +85,12 @@ class DbAuthMiddleware extends Middleware
             }
             return $this->responder->error(ErrorCode::AUTHENTICATION_REQUIRED, '');
         }
+        if ($method == 'GET' && $path == 'me') {
+            if (isset($_SESSION['user'])) {
+                return $this->responder->success($_SESSION['user']);
+            }
+            return $this->responder->error(ErrorCode::AUTHENTICATION_REQUIRED, '');
+        }
         if (!isset($_SESSION['user']) || !$_SESSION['user']) {
             $authenticationMode = $this->getProperty('mode', 'required');
             if ($authenticationMode == 'required') {

--- a/tests/functional/002_auth/003_db_auth.log
+++ b/tests/functional/002_auth/003_db_auth.log
@@ -18,6 +18,14 @@ Content-Length: 27
 
 {"id":2,"username":"user2"}
 ===
+GET /me
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 27
+
+{"id":2,"username":"user2"}
+===
 GET /records/invisibles/e42c77c6-06a4-4502-816c-d112c7142e6d
 ===
 200


### PR DESCRIPTION
Adds a `/me` endpoint to the dbAuth middleware which returns the current user (if you're logged in).