### PR TITLE
WIP: Add support for running raw SQL files

### DIFF
--- a/src/Tqdev/PhpCrudApi/Api.php
+++ b/src/Tqdev/PhpCrudApi/Api.php
@@ -13,6 +13,7 @@ use Tqdev\PhpCrudApi\Controller\ColumnController;
 use Tqdev\PhpCrudApi\Controller\GeoJsonController;
 use Tqdev\PhpCrudApi\Controller\JsonResponder;
 use Tqdev\PhpCrudApi\Controller\OpenApiController;
+use Tqdev\PhpCrudApi\Controller\ProcedureController;
 use Tqdev\PhpCrudApi\Controller\RecordController;
 use Tqdev\PhpCrudApi\Database\GenericDB;
 use Tqdev\PhpCrudApi\GeoJson\GeoJsonService;
@@ -37,6 +38,7 @@ use Tqdev\PhpCrudApi\Middleware\XsrfMiddleware;
 use Tqdev\PhpCrudApi\OpenApi\OpenApiService;
 use Tqdev\PhpCrudApi\Record\ErrorCode;
 use Tqdev\PhpCrudApi\Record\RecordService;
+use Tqdev\PhpCrudApi\Procedure\ProcedureService;
 use Tqdev\PhpCrudApi\ResponseUtils;
 
 class Api implements RequestHandlerInterface
@@ -137,6 +139,10 @@ class Api implements RequestHandlerInterface
                     $records = new RecordService($db, $reflection);
                     $geoJson = new GeoJsonService($reflection, $records);
                     new GeoJsonController($router, $responder, $geoJson);
+                    break;
+                case 'procedures':
+                    $procedures = new ProcedureService($db, $config->getProceduresDir());
+                    new ProcedureController($router, $responder, $procedures);
                     break;
             }
         }

--- a/src/Tqdev/PhpCrudApi/Api.php
+++ b/src/Tqdev/PhpCrudApi/Api.php
@@ -141,7 +141,7 @@ class Api implements RequestHandlerInterface
                     new GeoJsonController($router, $responder, $geoJson);
                     break;
                 case 'procedures':
-                    $procedures = new ProcedureService($db, $config->getProceduresDir());
+                    $procedures = new ProcedureService($db, $config->getProcedurePath());
                     new ProcedureController($router, $responder, $procedures);
                     break;
             }

--- a/src/Tqdev/PhpCrudApi/Config.php
+++ b/src/Tqdev/PhpCrudApi/Config.php
@@ -13,7 +13,7 @@ class Config
         'database' => null,
         'tables' => '',
         'middlewares' => 'cors,errors',
-        'controllers' => 'records,geojson,openapi',
+        'controllers' => 'records,geojson,procedures,openapi',
         'customControllers' => '',
         'customOpenApiBuilders' => '',
         'cacheType' => 'TempFile',
@@ -22,6 +22,7 @@ class Config
         'debug' => false,
         'basePath' => '',
         'openApiBase' => '{"info":{"title":"PHP-CRUD-API","version":"1.0.0"}}',
+        'proceduresDir' => './procedures/'
     ];
 
     private function getDefaultDriver(array $values): string
@@ -201,5 +202,10 @@ class Config
     public function getOpenApiBase(): array
     {
         return json_decode($this->values['openApiBase'], true);
+    }
+
+    public function getProceduresDir(): string
+    {
+        return $this->values['proceduresDir'];
     }
 }

--- a/src/Tqdev/PhpCrudApi/Config.php
+++ b/src/Tqdev/PhpCrudApi/Config.php
@@ -22,7 +22,7 @@ class Config
         'debug' => false,
         'basePath' => '',
         'openApiBase' => '{"info":{"title":"PHP-CRUD-API","version":"1.0.0"}}',
-        'proceduresDir' => './procedures/'
+        'procedurePath' => 'procedures'
     ];
 
     private function getDefaultDriver(array $values): string
@@ -204,8 +204,8 @@ class Config
         return json_decode($this->values['openApiBase'], true);
     }
 
-    public function getProceduresDir(): string
+    public function getProcedurePath(): string
     {
-        return $this->values['proceduresDir'];
+        return $this->values['procedurePath'];
     }
 }

--- a/src/Tqdev/PhpCrudApi/Controller/ProcedureController.php
+++ b/src/Tqdev/PhpCrudApi/Controller/ProcedureController.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tqdev\PhpCrudApi\Controller;
+
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Tqdev\PhpCrudApi\Middleware\Router\Router;
+use Tqdev\PhpCrudApi\Record\ErrorCode;
+use Tqdev\PhpCrudApi\Procedure\ProcedureService;
+use Tqdev\PhpCrudApi\RequestUtils;
+
+class ProcedureController
+{
+    private $service;
+    private $responder;
+
+    public function __construct(Router $router, Responder $responder, ProcedureService $service)
+    {
+        $router->register('GET', '/procedures/*', array($this, 'file'));
+        $this->service = $service;
+        $this->responder = $responder;
+    }
+
+    public function file(ServerRequestInterface $request): ResponseInterface
+    {
+        $file = RequestUtils::getPathSegment($request, 2);
+        $params = RequestUtils::getParams($request);
+        if (!$this->service->hasProcedure($file)) {
+            return $this->responder->error(ErrorCode::PROCEDURE_NOT_FOUND, $file);
+        }
+        return $this->responder->success($this->service->execute($file));
+    }
+}
+ 

--- a/src/Tqdev/PhpCrudApi/Controller/ProcedureController.php
+++ b/src/Tqdev/PhpCrudApi/Controller/ProcedureController.php
@@ -17,6 +17,9 @@ class ProcedureController
     public function __construct(Router $router, Responder $responder, ProcedureService $service)
     {
         $router->register('GET', '/procedures/*', array($this, 'file'));
+        $router->register('POST', '/procedures/*', array($this, 'file'));
+        $router->register('PUT', '/procedures/*', array($this, 'file'));
+        $router->register('DELETE', '/procedures/*', array($this, 'file'));
         $this->service = $service;
         $this->responder = $responder;
     }
@@ -24,11 +27,14 @@ class ProcedureController
     public function file(ServerRequestInterface $request): ResponseInterface
     {
         $file = RequestUtils::getPathSegment($request, 2);
-        $params = RequestUtils::getParams($request);
-        if (!$this->service->hasProcedure($file)) {
+        $operation = RequestUtils::getOperation($request);
+        $queryParams = RequestUtils::getParams($request, false);
+        $bodyParams = (array) $request->getParsedBody();
+        $params = array_merge($queryParams, $bodyParams);
+        if (!$this->service->hasProcedure($file, $operation)) {
             return $this->responder->error(ErrorCode::PROCEDURE_NOT_FOUND, $file);
-        }
-        return $this->responder->success($this->service->execute($file));
+        } 
+        return $this->responder->success($this->service->execute($file, $operation, $params));
     }
 }
  

--- a/src/Tqdev/PhpCrudApi/Controller/ProcedureController.php
+++ b/src/Tqdev/PhpCrudApi/Controller/ProcedureController.php
@@ -28,7 +28,9 @@ class ProcedureController
     {
         $file = RequestUtils::getPathSegment($request, 2);
         $operation = RequestUtils::getOperation($request);
-        $queryParams = RequestUtils::getParams($request, false);
+        $queryParams = array_map(function($param) {
+            return $param[0];
+        }, RequestUtils::getParams($request));
         $bodyParams = (array) $request->getParsedBody();
         $params = array_merge($queryParams, $bodyParams);
         if (!$this->service->hasProcedure($file, $operation)) {

--- a/src/Tqdev/PhpCrudApi/Database/GenericDB.php
+++ b/src/Tqdev/PhpCrudApi/Database/GenericDB.php
@@ -318,6 +318,14 @@ class GenericDB
         return $stmt->rowCount();
     }
 
+    public function rawSql(string $sql, array $parameters)
+    {
+        $stmt = $this->query($sql, $parameters);
+        $records = $stmt->fetchAll();
+
+        return $records;
+    }
+
     private function query(string $sql, array $parameters): \PDOStatement
     {
         $stmt = $this->pdo->prepare($sql);

--- a/src/Tqdev/PhpCrudApi/Database/GenericDB.php
+++ b/src/Tqdev/PhpCrudApi/Database/GenericDB.php
@@ -321,8 +321,14 @@ class GenericDB
     public function rawSql(string $sql, array $parameters)
     {
         $stmt = $this->query($sql, $parameters);
+        $stmt = $this->pdo->prepare($sql);
+        foreach ($parameters as $key => $value) {
+            if (strstr($sql, ':' . $key)) {
+                $stmt->bindParam(':' . $key, $value, \PDO::PARAM_STR);
+            }
+        }
+        $stmt->execute();
         $records = $stmt->fetchAll();
-
         return $records;
     }
 

--- a/src/Tqdev/PhpCrudApi/Procedure/ProcedureService.php
+++ b/src/Tqdev/PhpCrudApi/Procedure/ProcedureService.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Tqdev\PhpCrudApi\Procedure;
+
+use Tqdev\PhpCrudApi\Database\GenericDB;
+
+class ProcedureService {
+    private $db;
+    private $baseDir;
+
+    public function __construct(GenericDB $db, string $proceduresDir)
+    {
+        $this->db = $db;
+        $this->baseDir = $proceduresDir;
+    }
+
+    public function hasProcedure(string $procedureName) {
+        return file_exists($this->baseDir . $procedureName . '.sql');
+    }
+
+    public function execute(string $procedureName) {
+        $sql = file_get_contents($this->baseDir . $procedureName . '.sql');
+        return $this->db->rawSql($sql, []);
+    }
+}

--- a/src/Tqdev/PhpCrudApi/Procedure/ProcedureService.php
+++ b/src/Tqdev/PhpCrudApi/Procedure/ProcedureService.php
@@ -14,12 +14,19 @@ class ProcedureService {
         $this->baseDir = $proceduresDir;
     }
 
-    public function hasProcedure(string $procedureName) {
-        return file_exists($this->baseDir . $procedureName . '.sql');
+    public function hasProcedure(string $procedureName, string $operation) {
+        return file_exists($this->baseDir . $procedureName . '.' .$operation . '.sql');
     }
 
-    public function execute(string $procedureName) {
-        $sql = file_get_contents($this->baseDir . $procedureName . '.sql');
-        return $this->db->rawSql($sql, []);
+    public function execute(string $procedureName, string $operation, array $params = []) {
+        $sql = $this->parseSqlTemplate($this->baseDir . $procedureName . '.' . $operation . '.sql', $params);
+        return $this->db->rawSql($sql, $params);
+    }
+
+    private function parseSqlTemplate(string $path, array $context) {
+        ob_start();
+        extract($context);
+        include($path);
+        return ob_get_clean();
     }
 }

--- a/src/Tqdev/PhpCrudApi/Procedure/ProcedureService.php
+++ b/src/Tqdev/PhpCrudApi/Procedure/ProcedureService.php
@@ -6,20 +6,20 @@ use Tqdev\PhpCrudApi\Database\GenericDB;
 
 class ProcedureService {
     private $db;
-    private $baseDir;
+    private $procedurePath;
 
-    public function __construct(GenericDB $db, string $proceduresDir)
+    public function __construct(GenericDB $db, string $procedurePath)
     {
         $this->db = $db;
-        $this->baseDir = $proceduresDir;
+        $this->procedurePath = $procedurePath;
     }
 
     public function hasProcedure(string $procedureName, string $operation) {
-        return file_exists($this->baseDir . $procedureName . '.' .$operation . '.sql');
+        return file_exists('./' . $this->procedurePath . '/' . $procedureName . '.' .$operation . '.sql');
     }
 
     public function execute(string $procedureName, string $operation, array $params = []) {
-        $sql = $this->parseSqlTemplate($this->baseDir . $procedureName . '.' . $operation . '.sql', $params);
+        $sql = $this->parseSqlTemplate($this->procedurePath . '/' . $procedureName . '.' . $operation . '.sql', $params);
         return $this->db->rawSql($sql, $params);
     }
 

--- a/src/Tqdev/PhpCrudApi/Record/ErrorCode.php
+++ b/src/Tqdev/PhpCrudApi/Record/ErrorCode.php
@@ -33,6 +33,7 @@ class ErrorCode
     const PAGINATION_FORBIDDEN = 1019;
     const USER_ALREADY_EXIST = 1020;
     const PASSWORD_TOO_SHORT = 1021;
+	const PROCEDURE_NOT_FOUND = 1022;
 
     private $values = [
         9999 => ["%s", ResponseFactory::INTERNAL_SERVER_ERROR],
@@ -58,6 +59,7 @@ class ErrorCode
         1019 => ["Pagination forbidden", ResponseFactory::FORBIDDEN],
         1020 => ["User '%s' already exists", ResponseFactory::CONFLICT],
         1021 => ["Password too short (<%d characters)", ResponseFactory::UNPROCESSABLE_ENTITY],
+        1022 => ["Procedure '%s' not found", ResponseFactory::NOT_FOUND],
     ];
 
     public function __construct(int $code)

--- a/src/Tqdev/PhpCrudApi/RequestUtils.php
+++ b/src/Tqdev/PhpCrudApi/RequestUtils.php
@@ -19,12 +19,14 @@ class RequestUtils
         return isset($headers[0]) ? $headers[0] : '';
     }
 
-    public static function getParams(ServerRequestInterface $request): array
+    public static function getParams(ServerRequestInterface $request, bool $forceArray = true): array
     {
         $params = array();
         $query = $request->getUri()->getQuery();
         //$query = str_replace('][]=', ']=', str_replace('=', '[]=', $query));
-        $query = str_replace('%5D%5B%5D=', '%5D=', str_replace('=', '%5B%5D=', $query));
+        if ($forceArray) {
+            $query = str_replace('%5D%5B%5D=', '%5D=', str_replace('=', '%5B%5D=', $query));
+        }
         parse_str($query, $params);
         return $params;
     }
@@ -62,6 +64,17 @@ class RequestUtils
                         return 'delete';
                     case 'PATCH':
                         return 'increment';
+                }
+            case 'procedures':
+                switch ($method) {
+                    case 'POST':
+                        return 'write';
+                    case 'GET':
+                        return 'read';
+                    case 'PUT':
+                        return 'update';
+                    case 'DELETE':
+                        return 'delete';
                 }
         }
         return 'unknown';

--- a/src/Tqdev/PhpCrudApi/RequestUtils.php
+++ b/src/Tqdev/PhpCrudApi/RequestUtils.php
@@ -19,14 +19,12 @@ class RequestUtils
         return isset($headers[0]) ? $headers[0] : '';
     }
 
-    public static function getParams(ServerRequestInterface $request, bool $forceArray = true): array
+    public static function getParams(ServerRequestInterface $request): array
     {
         $params = array();
         $query = $request->getUri()->getQuery();
         //$query = str_replace('][]=', ']=', str_replace('=', '[]=', $query));
-        if ($forceArray) {
-            $query = str_replace('%5D%5B%5D=', '%5D=', str_replace('=', '%5B%5D=', $query));
-        }
+        $query = str_replace('%5D%5B%5D=', '%5D=', str_replace('=', '%5B%5D=', $query));
         parse_str($query, $params);
         return $params;
     }

--- a/src/procedures/example.read.sql
+++ b/src/procedures/example.read.sql
@@ -1,0 +1,4 @@
+SELECT p.id, p.content, c.name 
+FROM posts p
+INNER JOIN categories c ON c.id = p.category_id
+WHERE p.id = :id

--- a/src/procedures/example.sql
+++ b/src/procedures/example.sql
@@ -1,0 +1,3 @@
+SELECT p.id, p.content, c.name 
+FROM posts p
+INNER JOIN categories c ON c.id = p.category_id

--- a/src/procedures/example.write.sql
+++ b/src/procedures/example.write.sql
@@ -1,3 +1,4 @@
 SELECT p.id, p.content, c.name 
 FROM posts p
 INNER JOIN categories c ON c.id = p.category_id
+WHERE p.id = <?= $id ?>


### PR DESCRIPTION
Work in progress on this issue: https://github.com/mevdschee/php-crud-api/issues/422

Is this the direction you're looking for?

While setting this up I had some questions/concerns:

- On which routes do we want to serve these SQL files? 
- How do we distinguish between GET, POST, PUT etc.? Maybe some sort of comment/annotation on the top of the SQL file? Or do we introduce a PHP SQL parse dependency?
- Do we need a root JSON key for the result? Similar to records?
- Do we always serialize the result to an array? Or do we want to annotate SQL files for "single" record responses and serialize the first result into an object?
- Generating an OpenAPI spec for these endpoints is a bit hard. Do we want this? Maybe it's possible with a SQL parser package.
- I haven't read the code of all the middlewares, but I guess middlewares such as Authorization, MultiTenancy, PageLimits and Validation are pretty much tight to database tables, so those won't be usable on these "views"
- I discovered actual views can also be queried through this package. What is the exact "business case" of this feature? To support complex insert/updates?

Todos on this PR:

- [x] Accept/handle input arguments
- [ ] Tests
- [ ] Readme
- [x] Additional routes
- [ ] ~~JSON root key?~~
- [ ] OpenAPI spec generation?