### PR TITLE
XsrfMiddleware.php proposal

### DIFF
--- a/src/Tqdev/PhpCrudApi/Middleware/XsrfMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/XsrfMiddleware.php
@@ -20,7 +20,7 @@ class XsrfMiddleware extends Middleware
             $secure = isset($_SERVER['HTTPS']) && $_SERVER['HTTPS'] == 'on';
             $token = bin2hex(random_bytes(8));
             if (!headers_sent()) {
-                setcookie($cookieName, $token, 0, '', '', $secure);
+                setcookie($cookieName, $token, 0, '/', '', $secure);
             }
         }
         return $token;
@@ -33,7 +33,7 @@ class XsrfMiddleware extends Middleware
         $excludeMethods = $this->getArrayProperty('excludeMethods', 'OPTIONS,GET');
         if (!in_array($method, $excludeMethods)) {
             $headerName = $this->getProperty('headerName', 'X-XSRF-TOKEN');
-            if ($token != $request->getHeader($headerName)) {
+            if ($token != $request->getHeader($headerName)[0]) {
                 return $this->responder->error(ErrorCode::BAD_OR_MISSING_XSRF_TOKEN, '');
             }
         }


### PR DESCRIPTION
As described here: https://github.com/mevdschee/php-crud-api/issues/776#issue-841088753, I couldn't get the XsrfMiddleware to work.
Debugging extensively, I found two issues:

1) My front-end (Angular / httpClient) wasn't able to detect the XSRF-TOKEN Cookie, because its "path" value was not "/". Because of that, it did not send the X-XSRF-TOKEN Header. Setting the Cookie "path" value to "/" via XsrfMiddleware/getToken solved this problem.

2) When sending X-XSRF-TOKEN:	9aead2ceb0e150e1 in the Header, $request->getHeader($headerName) returns an Array ( [0] => 9aead2ceb0e150e1 ) - at least in my test cases. So "$token != $request->getHeader($headerName)" was always false. Changing the condition to "$token != $request->getHeader($headerName)[0]" solved this problem.

Tested with Mozilla Firefox 86.0.1 and Google Chrome Version 89.0.4389.72 (both on Linux).
Of course, I don't know if these changes have any unwanted side effects or will work in all environments.