### PR TITLE
fixes problem with multiple aud

### DIFF
--- a/src/Tqdev/PhpCrudApi/Middleware/JwtAuthMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/JwtAuthMiddleware.php
@@ -69,8 +69,12 @@ class JwtAuthMiddleware extends Middleware
         foreach ($requirements as $field => $values) {
             if (!empty($values)) {
                 if ($field != 'alg') {
-                    if (!isset($claims[$field]) || !in_array($claims[$field], $values)) {
-                        return array();
+                    if (!isset($claims[$field]) ) {
+                        if ( is_string( $claims[$field] ) && !in_array($claims[$field], $values) ) {
+                            return array();
+                        } else if ( is_array( $claims[$field] ) && !in_array($claims[$field][0], $values) && !in_array($claims[$field][1], $values) ) {
+                            return array();
+                        }
                     }
                 }
             }


### PR DESCRIPTION
In some cases, auth0 includes a second aud for userinfo endpoint.  Tokens can have multiple target audiences as long as the custom API’s signing algorithm is set to RS256.  Works with auth0 if machine-to-machine api userinfo is added as a second aud.  This patch prevents JWT validation from failing in that case.  See https://community.auth0.com/t/my-token-has-multiple-audiences-is-that-normal/41417