### PR TITLE
[dbAuth] add pkName to Columnnames if not contained inside 'dbAuth.returnedColumns'

### DIFF
--- a/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
@@ -112,7 +112,11 @@ class DbAuthMiddleware extends Middleware
                 if (strlen($newPassword) < $passwordLength) {
                     return $this->responder->error(ErrorCode::PASSWORD_TOO_SHORT, $passwordLength);
                 }
-                $users = $this->db->selectAll($table, $columnNames, $condition, $columnOrdering, 0, 1);
+                $userColumns = $columnNames;
+                if(!in_array($pkName, $columnNames)){
+                    array_push($userColumns, $pkName);
+                }
+                $users = $this->db->selectAll($table, $userColumns, $condition, $columnOrdering, 0, 1);
                 foreach ($users as $user) {
                     if (password_verify($password, $user[$passwordColumnName]) == 1) {
                         if (!headers_sent()) {
@@ -121,6 +125,9 @@ class DbAuthMiddleware extends Middleware
                         $data = [$passwordColumnName => password_hash($newPassword, PASSWORD_DEFAULT)];
                         $this->db->updateSingle($table, $data, $user[$pkName]);
                         unset($user[$passwordColumnName]);
+                        if(!in_array($pkName, $columnNames)){
+                            unset($user[$pkName]);
+                        }
                         return $this->responder->success($user);
                     }
                 }


### PR DESCRIPTION
If you try to change the password and `$pkName ` isn't contained inside `'dbAuth.returnedColumns'`, dbAuth won't know the column containing the id and will returns this error: 

<b>Warning</b>:  Undefined array key "id" in <b>C:\XAMPP\htdocs\api.php</b> on line <b>7978</b><br />
{"code":9999,"message":"Tqdev\\PhpCrudApi\\Database\\GenericDB::updateSingle(): Argument #3 ($id) must be of type string, null given, called in C:\\XAMPP\\htdocs\\api.php on line 7978"}