### PR TITLE
Add function support in SELECT query

### DIFF
--- a/src/Tqdev/PhpCrudApi/Database/ColumnsBuilder.php
+++ b/src/Tqdev/PhpCrudApi/Database/ColumnsBuilder.php
@@ -56,6 +56,11 @@ class ColumnsBuilder
     {
         $results = array();
         foreach ($columnNames as $columnName) {
+            //support SELECT COUNT(*) AS c .., by huangyifu
+            if(strpos($columnName,'(')>0 || strpos(trim($columnName),' ')>0){
+                $results[] = $columnName;
+                continue;
+            }//~
             $column = $table->getColumn($columnName);
             $quotedColumnName = $this->quoteColumnName($column);
             $quotedColumnName = $this->converter->convertColumnName($column, $quotedColumnName);

--- a/src/Tqdev/PhpCrudApi/Database/DataConverter.php
+++ b/src/Tqdev/PhpCrudApi/Database/DataConverter.php
@@ -51,6 +51,10 @@ class DataConverter
     public function convertRecords(ReflectedTable $table, array $columnNames, array &$records) /*: void*/
     {
         foreach ($columnNames as $columnName) {
+            //support SELECT COUNT(*) AS C function in SELECT, by huangyifu
+            if(strpos($columnName,'(')>0 || strpos(trim($columnName),' ')>0){
+                continue;
+            }//~
             $column = $table->getColumn($columnName);
             $conversion = $this->getRecordValueConversion($column);
             if ($conversion != 'none') {

--- a/src/Tqdev/PhpCrudApi/Record/ColumnIncluder.php
+++ b/src/Tqdev/PhpCrudApi/Record/ColumnIncluder.php
@@ -45,6 +45,12 @@ class ColumnIncluder
                 }
             }
         }
+        //support SELECT COUNT(*) AS C function in SELECT, by huangyifu
+        foreach (array_keys($columns) as $c) {				
+            if(strpos($c,'(')>0 || strpos(trim($c),' ')>0){
+                $result[] = $c;
+            }
+        }//~
         return $result;
     }
 


### PR DESCRIPTION
Add function support in SELECT query:

SELECT COUNT(*) AS C FROM ATABLE

https://127.0.0.1/api.php/records/mytest/?include=count(*)%20AS%20c