### PR TITLE
Do not check api key if request method is OPTIONS

### DIFF
--- a/src/Tqdev/PhpCrudApi/Middleware/ApiKeyDbAuthMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/ApiKeyDbAuthMiddleware.php
@@ -32,29 +32,32 @@ class ApiKeyDbAuthMiddleware extends Middleware
 
     public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface
     {
-        $user = false;
-        $headerName = $this->getProperty('header', 'X-API-Key');
-        $apiKey = RequestUtils::getHeader($request, $headerName);
-        if ($apiKey) {
-            $tableName = $this->getProperty('usersTable', 'users');
-            $table = $this->reflection->getTable($tableName);
-            $apiKeyColumnName = $this->getProperty('apiKeyColumn', 'api_key');
-            $apiKeyColumn = $table->getColumn($apiKeyColumnName);
-            $condition = new ColumnCondition($apiKeyColumn, 'eq', $apiKey);
-            $columnNames = $table->getColumnNames();
-            $columnOrdering = $this->ordering->getDefaultColumnOrdering($table);
-            $users = $this->db->selectAll($table, $columnNames, $condition, $columnOrdering, 0, 1);
-            if (count($users) < 1) {
-                return $this->responder->error(ErrorCode::AUTHENTICATION_FAILED, $apiKey);
+        $method = $request->getMethod();
+        if ($method != 'OPTIONS'){
+            $user = false;
+            $headerName = $this->getProperty('header', 'X-API-Key');
+            $apiKey = RequestUtils::getHeader($request, $headerName);
+            if ($apiKey) {
+                $tableName = $this->getProperty('usersTable', 'users');
+                $table = $this->reflection->getTable($tableName);
+                $apiKeyColumnName = $this->getProperty('apiKeyColumn', 'api_key');
+                $apiKeyColumn = $table->getColumn($apiKeyColumnName);
+                $condition = new ColumnCondition($apiKeyColumn, 'eq', $apiKey);
+                $columnNames = $table->getColumnNames();
+                $columnOrdering = $this->ordering->getDefaultColumnOrdering($table);
+                $users = $this->db->selectAll($table, $columnNames, $condition, $columnOrdering, 0, 1);
+                if (count($users) < 1) {
+                    return $this->responder->error(ErrorCode::AUTHENTICATION_FAILED, $apiKey);
+                }
+                $user = $users[0];
+            } else {
+                $authenticationMode = $this->getProperty('mode', 'required');
+                if ($authenticationMode == 'required') {
+                    return $this->responder->error(ErrorCode::AUTHENTICATION_REQUIRED, '');
+                }
             }
-            $user = $users[0];
-        } else {
-            $authenticationMode = $this->getProperty('mode', 'required');
-            if ($authenticationMode == 'required') {
-                return $this->responder->error(ErrorCode::AUTHENTICATION_REQUIRED, '');
-            }
+            $_SESSION['apiUser'] = $user;
         }
-        $_SESSION['apiUser'] = $user;
         return $next->handle($request);
     }
 }


### PR DESCRIPTION
Fix for issue #889
The same fix is probably necessary for other auth methods as well, but I have not tested that.
If my understanding of how cors work is correct, bypassing auth on OPTIONS-requests is not only safe but also necessary.