### PR TITLE
prevent empty username on dbauth register endpoint

### DIFF
--- a/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
@@ -73,6 +73,9 @@ class DbAuthMiddleware extends Middleware
                 if (!$registerUser) {
                     return $this->responder->error(ErrorCode::AUTHENTICATION_FAILED, $username);
                 }
+                if(strlen(trim($username)) == 0){
+                    return $this->responder->error(ErrorCode::USERNAME_EMPTY, $username);
+                }
                 if (strlen($password) < $passwordLength) {
                     return $this->responder->error(ErrorCode::PASSWORD_TOO_SHORT, $passwordLength);
                 }

--- a/src/Tqdev/PhpCrudApi/Record/ErrorCode.php
+++ b/src/Tqdev/PhpCrudApi/Record/ErrorCode.php
@@ -33,6 +33,7 @@ class ErrorCode
     const PAGINATION_FORBIDDEN = 1019;
     const USER_ALREADY_EXIST = 1020;
     const PASSWORD_TOO_SHORT = 1021;
+    const USERNAME_EMPTY = 1022;
 
     private $values = [
         0000 => ["Success", ResponseFactory::OK],
@@ -58,6 +59,7 @@ class ErrorCode
         1019 => ["Pagination forbidden", ResponseFactory::FORBIDDEN],
         1020 => ["User '%s' already exists", ResponseFactory::CONFLICT],
         1021 => ["Password too short (<%d characters)", ResponseFactory::UNPROCESSABLE_ENTITY],
+        1022 => ["Username is empty or only whitespaces", ResponseFactory::UNPROCESSABLE_ENTITY],
         9999 => ["%s", ResponseFactory::INTERNAL_SERVER_ERROR],
     ];
 


### PR DESCRIPTION
#### I propose the following change:

Prevent empty or only whitespace username on dbauth register endpoint. What's your thoughts about this?