### PR TITLE
Update DbAuthMiddleware to refresh session data via /me endpoint 

### DIFF
--- a/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
@@ -128,6 +128,7 @@ class DbAuthMiddleware extends Middleware
                             session_regenerate_id(true);
                         }
                         unset($user[$passwordColumnName]);
+                        $user['updatedAt'] = time();
                         $_SESSION['user'] = $user;
                         return $this->responder->success($user);
                     }
@@ -176,6 +177,24 @@ class DbAuthMiddleware extends Middleware
         }
         if ($method == 'GET' && $path == 'me') {
             if (isset($_SESSION['user'])) {
+                $updateAfter = $this->getProperty('updateSessionData',0) * 60; 
+                $passwordColumnName = $this->getProperty('passwordColumn','password');
+                if($updateAfter > 0 && (time() > ($_SESSION['user']['updatedAt'] + $updateAfter))){
+                    $tableName = $this->getProperty('loginTable','users');
+                    $table = $this->reflection->getTable($tableName);
+                    $pkName = $table->getPk()->getName();
+                    $returnedColumns = $this->getProperty('returnedColumns','');
+                    if(!$returnedColumns){
+                        $columnNames = $table->getColumnNames();
+                    }else{
+                        $columnNames = array_map('trim',explode(',',$returnedColumns));
+                        $columnNames = array_values(array_unique($columnNames));
+                    }
+                    $user = $this->db->selectSingle($table,$columnNames,$_SESSION['user'][$pkName]);
+                    unset($user[$passwordColumnName]);
+                    $user['updatedAt'] = time();
+                    $_SESSION['user'] = $user;
+                }
                 return $this->responder->success($_SESSION['user']);
             }
             return $this->responder->error(ErrorCode::AUTHENTICATION_REQUIRED, '');


### PR DESCRIPTION
Refer to [935](https://github.com/mevdschee/php-crud-api/issues/935)

Add new property `dbAuth.refreshSession` to indicate whether the session data will be updated every `x` minutes. Also new session key (`updatedAt`) to record the time of creation/updating of session