### PR TITLE
Updated DbAuthMiddleware to trim leading and/or trailing spaces in username

### DIFF
--- a/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/DbAuthMiddleware.php
@@ -44,7 +44,7 @@ class DbAuthMiddleware extends Middleware
         $method = $request->getMethod();
         if ($method == 'POST' && in_array($path, ['login', 'register', 'password'])) {
             $body = $request->getParsedBody();
-            $username = isset($body->username) ? $body->username : '';
+            $username = trim(isset($body->username) ? $body->username : '');
             $password = isset($body->password) ? $body->password : '';
             $newPassword = isset($body->newPassword) ? $body->newPassword : '';
             $tableName = $this->getProperty('usersTable', 'users');


### PR DESCRIPTION
Updated middleware to trim leading and/or trailing spaces in username. Before this, if a username is `jsmith`, `jsmith  ` or ` jsmith` will result to authentication failed due to extra spaces before or after the printable or visible characters in the username. Not sure if it is intentional, but it's confusing if these usernames will be treated as distinct. 😁