### PR TITLE
To hide api.php from url

### DIFF
--- a/README.md
+++ b/README.md
@@ -1594,7 +1594,7 @@ server {
     server_name server_domain_or_IP;
 
     location / {
-        try_files $uri $uri/ =404;
+        try_files $uri $uri/ /api.php?$args;  
     }
 
     location ~ [^/]\.php(/|$) {


### PR DESCRIPTION
to hide api.php  from url on nginx,
replace this  "try_files $uri $uri/ =404;" by  "try_files $uri $uri/ /api.php?$args;" on the ReadMe