### PR TITLE
Bug1044

### DIFF
--- a/src/Tqdev/PhpCrudApi/Api.php
+++ b/src/Tqdev/PhpCrudApi/Api.php
@@ -62,7 +62,7 @@ class Api implements RequestHandlerInterface
             $config->getPassword(),
             $config->getGeometrySrid()
         );
-        $prefix = sprintf('phpcrudapi-%s-', substr(md5(__FILE__), 0, 8));
+        $prefix = sprintf('phpcrudapi-%s-', substr($config->getUID()), 0, 8));
         $cache = CacheFactory::create($config->getCacheType(), $prefix, $config->getCachePath());
         $reflection = new ReflectionService($db, $cache, $config->getCacheTime());
         $responder = new JsonResponder($config->getJsonOptions(), $config->getDebug());

--- a/src/Tqdev/PhpCrudApi/Config/Config.php
+++ b/src/Tqdev/PhpCrudApi/Config/Config.php
@@ -29,7 +29,12 @@ class Config implements ConfigInterface
         'openApiBase' => '{"info":{"title":"PHP-CRUD-API","version":"1.0.0"}}',
         'geometrySrid' => 4326,
     ];
-
+    
+    public function getUID(): string
+    {
+        return md5(json_encode($this->values));
+    }
+    
     private function getDefaultDriver(array $values): string
     {
         if (isset($values['driver'])) {


### PR DESCRIPTION
as discussed in https://github.com/mevdschee/php-crud-api/issues/1044
use the md5 of the entire json encoded config as a cache key..

as config->values is private, created a getUID function (that create a MD5 of config->values)
and replace md5(__FILE__) with it..
