### PR TITLE
support filters on related tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -387,8 +387,35 @@ instead of "AND" should be applied. Note that you can also repeat "filter1" and
 create an "AND" within an "OR". Since you can also go one level deeper by adding
 a letter (a-f) you can create almost any reasonably complex condition tree.
 
-NB: You can only filter on the requested table (not on it's included tables) and
-filters are only applied on list calls.
+### Filters on related tables
+
+You can also filter on a related table by prefixing the column with the path of
+table names to it, the same names you would use in the "join" parameter. For
+example, to list the posts that have a comment containing the word "great":
+
+    GET /records/posts?filter=comments.message,cs,great
+
+This works for all three relation types (belongsTo, hasMany and
+hasAndBelongsToMany) and the path may be more than one table deep:
+
+    GET /records/posts?filter=categories.name,eq,announcement
+    GET /records/posts?filter=tags.name,eq,funny
+    GET /records/posts?filter=comments.categories.name,eq,comment
+
+A related filter keeps a record when at least one matching related record
+exists (it is translated into an SQL "EXISTS" sub-query), so the result is the
+set of requested records and pagination and counts are applied to that set. The
+related records themselves are not filtered: if you also add the table to the
+"join" parameter, the nested results still contain all related records. The
+related table does not need to be listed in the "join" parameter for the filter
+to work. Related filters can be combined and grouped with normal filters using
+the "filter1"/"filter2" syntax described above.
+
+Authorization and multi-tenancy are respected on the related table: a filter can
+only match records that a direct request on that table would be allowed to see,
+so it does not become a way around your access rules.
+
+NB: Filters are only applied on list calls.
 
 ### Column selection
 

--- a/V3_PLAN.md
+++ b/V3_PLAN.md
@@ -1,0 +1,238 @@
+# PHP-CRUD-API v3 plan: internal joins + filters on child tables
+
+## Goal
+
+A v3 that is a strict superset of v2:
+
+1. Same endpoints, same request surface, byte-identical responses for every
+   existing v2 request (no regressions in the test suite).
+2. Adds one new capability: **filters that target joined/child tables**, pushed
+   into SQL via joins instead of being done in PHP.
+
+"Fully compatible with v2 (but allows filters on child tables)" is read as
+**purely additive**: existing requests behave exactly as before, new requests
+that reference a related table in a `filter` get the new behavior. No version
+flag, no separate endpoint, no opt-in config required.
+
+## Current architecture (what we keep working)
+
+- `RecordController::_list` -> `RecordService::_list`.
+- Root table queried once via `GenericDB::selectAll(table, columns, condition, ordering, offset, limit)`.
+- `RelationJoiner::addJoins` then runs **separate batched queries** per relation
+  (`selectMultiple` / `selectAll` with `IN (...)`) and stitches nested results
+  in PHP. This is why output is clean, pagination is correct, and there is no
+  cartesian explosion. We do NOT throw this away.
+- `FilterInfo::getCombinedConditions` builds a `Condition` tree for the **root
+  table only**. `ConditionsBuilder` renders it to a `WHERE` clause.
+- Relations are detected in `RelationJoiner`: `belongsTo` (root has FK to target),
+  `hasMany` (target has FK to root), `hasAndBelongsToMany` (junction table with
+  FKs to both).
+
+## Design decision 1: join strategy (DECIDED: hybrid)
+
+The phrase "internally does joins" has two readings. We choose where joins are used:
+
+- **Hybrid (recommended).** Keep the proven batched per-relation assembly for
+  building the response tree (guarantees identical v2 output, correct
+  pagination, no cartesian blow-up). Use real SQL joins only where they add a
+  new capability: compiling child-table filters into correlated `EXISTS`
+  semi-joins on the parent query. Lowest risk, fully v2-compatible.
+- **Full single-query join (alternative).** Emit one big `LEFT JOIN` per
+  root-to-leaf path, fetch flattened rows, regroup into the nested tree in PHP.
+  Pure "joins", but: cartesian explosion with sibling `hasMany` branches
+  (comments x tags), pagination requires paginating the root via a derived
+  table / window function, and it is a much larger rewrite of `GenericDB`.
+  Higher risk, often slower for multi-branch joins.
+
+This plan is written for the **hybrid** approach.
+
+## Design decision 2: child-filter semantics (DECIDED: restrict parents)
+
+When a filter targets a child table, e.g. `filter=comments.message,cs,great`:
+
+- **A. Restrict parents (recommended default).** Return only root records that
+  have at least one matching child (SQL `EXISTS`). The nested child arrays still
+  contain all children, exactly as v2. Pagination and count reflect the filtered
+  parent set.
+- **B. Restrict children.** Return all parents, but the nested child array only
+  contains matching children.
+- **C. Both.** Restrict parents AND show only matching children.
+
+The plumbing built here supports all three by toggling where the compiled filter
+is applied (parent `WHERE` vs the batched child query). We implement **A** as the
+default; B/C become a follow-up toggle if wanted. `belongsTo` filters always act
+as parent restriction (filtering a single nested object is meaningless).
+
+## Syntax
+
+Reuse the existing `filter` parameter; allow a relation path in the column slot,
+consistent with `include=categories.name` and `join=categories`:
+
+```
+GET /records/posts?join=comments&filter=comments.message,cs,great   # hasMany
+GET /records/posts?filter=categories.name,eq,announcement           # belongsTo
+GET /records/posts?join=tags&filter=tags.name,eq,funny              # HABTM
+GET /records/posts?filter=comments.users.username,eq,bob           # nested
+```
+
+Rules:
+- The path uses **table names** (matching `join`/`include`), not FK column names.
+- `filter=id,eq,1` (no relation prefix) stays root-table, identical to v2.
+- A child filter does **not** require the table to also appear in `join`;
+  parent restriction via `EXISTS` needs no returned data. To also get the
+  children in the output, the client adds `join` as usual.
+- The existing OR/AND grouping (`filter1`, `filter2`) is unchanged; the relation
+  path lives in the value's column slot, the grouping in the key suffix.
+- Parsing: split the column token on the first dot; if the leading segment is a
+  table reachable from the current table by a relation, treat it as a relation
+  path, else treat the whole token as a (root) column name.
+
+## Generated SQL (parent restriction via correlated EXISTS)
+
+hasMany (`filter=comments.message,cs,great`):
+```sql
+SELECT ... FROM "posts" WHERE EXISTS (
+  SELECT 1 FROM "comments"
+  WHERE "comments"."post_id" = "posts"."id" AND "comments"."message" LIKE ?
+)
+```
+belongsTo (`filter=categories.name,eq,announcement`):
+```sql
+SELECT ... FROM "posts" WHERE EXISTS (
+  SELECT 1 FROM "categories"
+  WHERE "categories"."id" = "posts"."category_id" AND "categories"."name" = ?
+)
+```
+HABTM (`filter=tags.name,eq,funny`):
+```sql
+SELECT ... FROM "posts" WHERE EXISTS (
+  SELECT 1 FROM "post_tags"
+  JOIN "tags" ON "tags"."id" = "post_tags"."tag_id"
+  WHERE "post_tags"."post_id" = "posts"."id" AND "tags"."name" = ?
+)
+```
+Nested EXISTS compose. Subquery tables get unique aliases per depth so
+self-referencing relations and repeated table names stay unambiguous.
+
+This keeps `GenericDB::selectAll` and `selectCount` unchanged: they already take
+a `Condition` and render a `WHERE`. The `Condition` tree just gets richer, so
+**count and pagination stay correct for free**.
+
+## Implementation steps (hybrid)
+
+1. **Relation resolver.** Factor relation classification (belongsTo / hasMany /
+   HABTM + resolved keys/junction) out of `RelationJoiner` into a small reusable
+   helper so the filter compiler and the joiner agree on how a table-name path
+   maps to keys. (`src/Tqdev/PhpCrudApi/Record/`.)
+2. **New condition type** `Record/Condition/RelatedCondition.php`: carries the
+   resolved relation step(s) (ReflectedTable + key columns + optional junction)
+   and the inner `Condition`. Resolution stays in PHP/reflection; the builder
+   stays SQL-only.
+3. **`Database/ConditionsBuilder.php`**: render `RelatedCondition` as a
+   correlated `EXISTS (...)` with per-depth aliasing, reusing existing column
+   SQL for the leaf condition. Handle the four drivers (mysql/pgsql/sqlsrv/sqlite).
+4. **`Record/FilterInfo.php`**: give it `ReflectionService`. Split incoming
+   filters into root-table conditions (as today) and relation-path conditions;
+   compile the latter into `RelatedCondition`s AND-ed (or OR-ed per grouping)
+   into the combined condition. Keep the existing `filter1`/`filter2` grouping.
+5. **`Record/RecordService.php`**: pass `ReflectionService` into `FilterInfo`.
+   (Hooks for semantic B/C: also hand the per-relation child filters to the
+   joiner; default A leaves the joiner unchanged.)
+6. **Limits / safety.** Make `JoinLimitsMiddleware` (depth/tables/records) also
+   account for filter relation paths so child filters cannot bypass anti-scraping
+   limits. Reject/ignore unresolvable paths the same way unknown joins are ignored.
+7. **OpenAPI.** Confirm `OpenApi*Builder` still generates valid specs; document
+   the new filter-path capability if the generator enumerates filterable columns.
+8. **Build + tests** (below).
+
+## Files touched (hybrid)
+
+- `src/Tqdev/PhpCrudApi/Record/FilterInfo.php` (split root vs relation filters)
+- `src/Tqdev/PhpCrudApi/Record/Condition/RelatedCondition.php` (new)
+- `src/Tqdev/PhpCrudApi/Database/ConditionsBuilder.php` (render EXISTS)
+- `src/Tqdev/PhpCrudApi/Record/RecordService.php` (wire reflection into FilterInfo)
+- `src/Tqdev/PhpCrudApi/Record/RelationJoiner.php` (only if B/C: child restriction)
+- `src/Tqdev/PhpCrudApi/Middleware/JoinLimitsMiddleware.php` (cover filter paths)
+- relation resolver helper (new, factored from `RelationJoiner`)
+
+## Status: implemented
+
+Done on branch `v3` (hybrid + restrict-parents, as decided):
+
+- `Record/Condition/RelatedCondition.php` (new): belongsTo/hasMany/habtm EXISTS node.
+- `Record/RelationResolver.php` (new): resolves a table-name hop to keys/junction.
+- `Record/FilterInfo.php`: compiles dotted filter paths into RelatedConditions,
+  falls back to v2 behavior for non-dotted columns; given ReflectionService.
+- `Database/ConditionsBuilder.php`: renders RelatedCondition as correlated
+  EXISTS with per-depth aliases (`_cf0`, `_cf1`, ...); inner conditions are
+  qualified with the related-table alias. Top-level column SQL is unchanged.
+- `Database/GenericDB.php`: `selectAll`/`selectCount` pass the root table ref so
+  EXISTS sub-queries correlate; count and pagination use the same condition.
+- `RequestUtils.php`: `getTableNames` also returns filter-path tables so table
+  and column authorization cover filtered tables.
+- `Middleware/JoinLimitsMiddleware.php`: caps relation-filter path depth to the
+  configured join depth.
+- `Record/FilterInfo.php`: each related table's authorization.recordHandler and
+  multiTenancy conditions are pushed into its EXISTS sub-query (same conditions a
+  direct query of that table would get), so related filters cannot leak rows that
+  record-level authorization or multi-tenancy would hide.
+- 11 functional tests `tests/functional/001_records/096..106` (hasMany,
+  belongsTo, habtm, nested, parent-restrict-keeps-children, pagination+count,
+  OR-grouping, negation, graceful-ignore, record-auth respected, multi-tenancy
+  respected).
+
+Verified: full suite 130 tests, 0 failed on both mysql and pgsql; phpstan level 5
+clean for the changed files (the only reported error is a pre-existing one in
+WpAuthMiddleware caused by the missing wordpress stub in this checkout).
+sqlsrv/sqlite not run here (no PDO drivers/containers available); the generated
+EXISTS SQL uses only standard, already-used quoting and should port, but should
+be run before release.
+
+## Security: authorization and multi-tenancy on related filters
+
+All three middleware-condition layers are now enforced on a related filter, so
+it is not a hole around v2's access controls:
+
+- Table-level authorization: a denied related table is removed from reflection,
+  so the resolver cannot see it and the filter is ignored (via getTableNames).
+- Column-level authorization: a denied column is removed, so a filter on it is
+  ignored (via getTableNames).
+- Record-level authorization (authorization.recordHandler) and multi-tenancy
+  conditions are AND-ed into each related table's EXISTS sub-query (FilterInfo),
+  so a related filter only matches rows the caller is allowed to see. Covered by
+  tests 105 (record auth) and 106 (multi-tenancy).
+
+## Known limitations (follow-ups)
+
+- When the outer table has more than one foreign key to the same related table,
+  the first foreign key is used for the correlation. v2's join has the same
+  ambiguity. A future syntax could disambiguate by FK column.
+
+## Out of scope for v3 v1 (note as future)
+
+- Ordering on joined/child columns (`order=comments.created`) - v2 forbids it; keep parity.
+- Aggregates on children (counts, sums).
+- Full single-query join mode (decision 1 alternative).
+
+## Testing
+
+- Workflow: edit `src/` -> `php build.php` (regenerates `api.php` and
+  `api.include.php`) -> `php test.php`. The test harness `require`s
+  `api.include.php`, so a build is required before running tests.
+- Regression: run the full existing suite (esp. `tests/functional/001_records`)
+  to prove byte-identical v2 behavior. Target sqlite first, then mysql/pgsql/
+  sqlsrv via docker.
+- New `.log` fixtures under `tests/functional/001_records/` covering:
+  - child filter on hasMany, belongsTo, HABTM
+  - nested relation path
+  - OR/AND grouping with a relation path (`filter1`/`filter2`)
+  - pagination + count correctness with a child filter
+  - root filter unchanged (no relation prefix)
+- `phpstan` (see `phpstan.neon`) must pass.
+
+## Compatibility guarantees
+
+- No new required config; no endpoint/version changes.
+- Existing requests produce identical SQL shape and identical JSON.
+- New behavior only triggers when a `filter` value's column token names a
+  related table reachable from the queried table.

--- a/api.include.php
+++ b/api.include.php
@@ -2267,67 +2267,98 @@ namespace Tqdev\PhpCrudApi\Database {
     use Tqdev\PhpCrudApi\Record\Condition\NoCondition;
     use Tqdev\PhpCrudApi\Record\Condition\NotCondition;
     use Tqdev\PhpCrudApi\Record\Condition\OrCondition;
+    use Tqdev\PhpCrudApi\Record\Condition\RelatedCondition;
     use Tqdev\PhpCrudApi\Record\Condition\SpatialCondition;
     class ConditionsBuilder
     {
         private $driver;
         private $geometrySrid;
+        private $aliasSeq;
         public function __construct(string $driver, int $geometrySrid)
         {
             $this->driver = $driver;
             $this->geometrySrid = $geometrySrid;
+            $this->aliasSeq = 0;
         }
-        private function getConditionSql(Condition $condition, array &$arguments): string
+        private function nextAlias(): string
+        {
+            return '_cf' . $this->aliasSeq++;
+        }
+        private function getConditionSql(Condition $condition, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
         {
             if ($condition instanceof AndCondition) {
-                return $this->getAndConditionSql($condition, $arguments);
+                return $this->getAndConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             if ($condition instanceof OrCondition) {
-                return $this->getOrConditionSql($condition, $arguments);
+                return $this->getOrConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             if ($condition instanceof NotCondition) {
-                return $this->getNotConditionSql($condition, $arguments);
+                return $this->getNotConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             if ($condition instanceof SpatialCondition) {
-                return $this->getSpatialConditionSql($condition, $arguments);
+                return $this->getSpatialConditionSql($condition, $arguments, $columnAlias);
+            }
+            if ($condition instanceof RelatedCondition) {
+                return $this->getRelatedConditionSql($condition, $arguments, $correlationRef);
             }
             if ($condition instanceof ColumnCondition) {
-                return $this->getColumnConditionSql($condition, $arguments);
+                return $this->getColumnConditionSql($condition, $arguments, $columnAlias);
             }
             throw new \Exception('Unknown Condition: ' . get_class($condition));
         }
-        private function getAndConditionSql(AndCondition $and, array &$arguments): string
+        private function getAndConditionSql(AndCondition $and, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
         {
             $parts = [];
             foreach ($and->getConditions() as $condition) {
-                $parts[] = $this->getConditionSql($condition, $arguments);
+                $parts[] = $this->getConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             return '(' . implode(' AND ', $parts) . ')';
         }
-        private function getOrConditionSql(OrCondition $or, array &$arguments): string
+        private function getOrConditionSql(OrCondition $or, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
         {
             $parts = [];
             foreach ($or->getConditions() as $condition) {
-                $parts[] = $this->getConditionSql($condition, $arguments);
+                $parts[] = $this->getConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             return '(' . implode(' OR ', $parts) . ')';
         }
-        private function getNotConditionSql(NotCondition $not, array &$arguments): string
+        private function getNotConditionSql(NotCondition $not, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
         {
             $condition = $not->getCondition();
-            return '(NOT ' . $this->getConditionSql($condition, $arguments) . ')';
+            return '(NOT ' . $this->getConditionSql($condition, $arguments, $columnAlias, $correlationRef) . ')';
         }
-        private function quoteColumnName(ReflectedColumn $column): string
+        private function quoteColumnName(ReflectedColumn $column, string $alias = ''): string
         {
+            if ($alias !== '') {
+                return '"' . $alias . '"."' . $column->getRealName() . '"';
+            }
             return '"' . $column->getRealName() . '"';
+        }
+        private function getRelatedConditionSql(RelatedCondition $condition, array &$arguments, string $correlationRef): string
+        {
+            $relatedTable = '"' . $condition->getRelatedTable()->getRealName() . '"';
+            $outerRef = $correlationRef . '.' . $this->quoteColumnName($condition->getOuterColumn());
+            if ($condition->getKind() === 'habtm') {
+                $junctionAlias = $this->nextAlias();
+                $relatedAlias = $this->nextAlias();
+                $junctionTable = '"' . $condition->getJunctionTable()->getRealName() . '"';
+                $joinOn = $this->quoteColumnName($condition->getRelatedColumn(), $relatedAlias) . ' = ' . $this->quoteColumnName($condition->getJunctionToRelatedColumn(), $junctionAlias);
+                $correlate = $this->quoteColumnName($condition->getJunctionToOuterColumn(), $junctionAlias) . ' = ' . $outerRef;
+                $inner = $this->getConditionSql($condition->getCondition(), $arguments, $relatedAlias, '"' . $relatedAlias . '"');
+                return 'EXISTS (SELECT 1 FROM ' . $junctionTable . ' "' . $junctionAlias . '" JOIN ' . $relatedTable . ' "' . $relatedAlias . '" ON ' . $joinOn . ' WHERE ' . $correlate . ' AND ' . $inner . ')';
+            }
+            $relatedAlias = $this->nextAlias();
+            $correlate = $this->quoteColumnName($condition->getRelatedColumn(), $relatedAlias) . ' = ' . $outerRef;
+            $inner = $this->getConditionSql($condition->getCondition(), $arguments, $relatedAlias, '"' . $relatedAlias . '"');
+            return 'EXISTS (SELECT 1 FROM ' . $relatedTable . ' "' . $relatedAlias . '" WHERE ' . $correlate . ' AND ' . $inner . ')';
         }
         private function escapeLikeValue(string $value): string
         {
             return addcslashes($value, '%_');
         }
-        private function getColumnConditionSql(ColumnCondition $condition, array &$arguments): string
+        private function getColumnConditionSql(ColumnCondition $condition, array &$arguments, string $columnAlias = ''): string
         {
-            $column = $this->quoteColumnName($condition->getColumn());
+            $column = $this->quoteColumnName($condition->getColumn(), $columnAlias);
             $operator = $condition->getOperator();
             $value = $condition->getValue();
             $sql = 'FALSE';
@@ -2440,9 +2471,9 @@ namespace Tqdev\PhpCrudApi\Database {
             }
             return '';
         }
-        private function getSpatialConditionSql(ColumnCondition $condition, array &$arguments): string
+        private function getSpatialConditionSql(ColumnCondition $condition, array &$arguments, string $columnAlias = ''): string
         {
-            $column = $this->quoteColumnName($condition->getColumn());
+            $column = $this->quoteColumnName($condition->getColumn(), $columnAlias);
             $operator = $condition->getOperator();
             $value = $condition->getValue();
             $functionName = $this->getSpatialFunctionName($operator);
@@ -2453,12 +2484,13 @@ namespace Tqdev\PhpCrudApi\Database {
             }
             return $sql;
         }
-        public function getWhereClause(Condition $condition, array &$arguments): string
+        public function getWhereClause(Condition $condition, array &$arguments, string $tableRef = ''): string
         {
             if ($condition instanceof NoCondition) {
                 return '';
             }
-            return ' WHERE ' . $this->getConditionSql($condition, $arguments);
+            $this->aliasSeq = 0;
+            return ' WHERE ' . $this->getConditionSql($condition, $arguments, '', $tableRef);
         }
     }
 }
@@ -2818,7 +2850,7 @@ namespace Tqdev\PhpCrudApi\Database {
             $tableRealName = $table->getRealName();
             $condition = $this->addMiddlewareConditions($tableName, $condition);
             $parameters = array();
-            $whereClause = $this->conditions->getWhereClause($condition, $parameters);
+            $whereClause = $this->conditions->getWhereClause($condition, $parameters, '"' . $tableRealName . '"');
             $sql = 'SELECT COUNT(*) FROM "' . $tableRealName . '"' . $whereClause;
             $stmt = $this->query($sql, $parameters);
             return $stmt->fetchColumn(0);
@@ -2845,7 +2877,7 @@ namespace Tqdev\PhpCrudApi\Database {
             $tableRealName = $table->getRealName();
             $condition = $this->addMiddlewareConditions($tableName, $condition);
             $parameters = array();
-            $whereClause = $this->conditions->getWhereClause($condition, $parameters);
+            $whereClause = $this->conditions->getWhereClause($condition, $parameters, '"' . $tableRealName . '"');
             $orderBy = $this->columns->getOrderBy($table, $columnOrdering);
             $offsetLimit = $this->columns->getOffsetLimit($offset, $limit);
             $sql = 'SELECT ' . $selectColumns . ' FROM "' . $tableRealName . '"' . $whereClause . $orderBy . $offsetLimit;
@@ -4937,32 +4969,75 @@ namespace Tqdev\PhpCrudApi\Middleware {
         {
             parent::__construct($router, $responder, $config, $middleware);
         }
+        private function hasRelationFilter(array $params): bool
+        {
+            foreach ($params as $key => $values) {
+                if (substr($key, 0, 6) != 'filter' || !is_array($values)) {
+                    continue;
+                }
+                foreach ($values as $value) {
+                    if (strpos(explode(',', $value, 2)[0], '.') !== false) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        private function limitFilterDepth(array $params, int $maxDepth): array
+        {
+            foreach ($params as $key => $values) {
+                if (substr($key, 0, 6) != 'filter' || !is_array($values)) {
+                    continue;
+                }
+                $kept = array();
+                foreach ($values as $value) {
+                    // the number of dots in the column path equals the number of
+                    // related tables traversed, mirroring the join depth limit
+                    if (substr_count(explode(',', $value, 2)[0], '.') <= $maxDepth) {
+                        $kept[] = $value;
+                    }
+                }
+                if (count($kept) > 0) {
+                    $params[$key] = $kept;
+                } else {
+                    unset($params[$key]);
+                }
+            }
+            return $params;
+        }
         public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface
         {
             $operation = RequestUtils::getOperation($request);
             $params = RequestUtils::getParams($request);
-            if (in_array($operation, ['read', 'list']) && isset($params['join'])) {
+            $hasJoin = isset($params['join']);
+            $hasRelationFilter = $this->hasRelationFilter($params);
+            if (in_array($operation, ['read', 'list']) && ($hasJoin || $hasRelationFilter)) {
                 $maxDepth = (int) $this->getProperty('depth', '3');
                 $maxTables = (int) $this->getProperty('tables', '10');
                 $maxRecords = (int) $this->getProperty('records', '1000');
-                $tableCount = 0;
-                $joinPaths = array();
-                for ($i = 0; $i < count($params['join']); $i++) {
-                    $joinPath = array();
-                    $tables = explode(',', $params['join'][$i]);
-                    for ($depth = 0; $depth < min($maxDepth, count($tables)); $depth++) {
-                        array_push($joinPath, $tables[$depth]);
-                        $tableCount += 1;
+                if ($hasJoin) {
+                    $tableCount = 0;
+                    $joinPaths = array();
+                    for ($i = 0; $i < count($params['join']); $i++) {
+                        $joinPath = array();
+                        $tables = explode(',', $params['join'][$i]);
+                        for ($depth = 0; $depth < min($maxDepth, count($tables)); $depth++) {
+                            array_push($joinPath, $tables[$depth]);
+                            $tableCount += 1;
+                            if ($tableCount == $maxTables) {
+                                break;
+                            }
+                        }
+                        array_push($joinPaths, implode(',', $joinPath));
                         if ($tableCount == $maxTables) {
                             break;
                         }
                     }
-                    array_push($joinPaths, implode(',', $joinPath));
-                    if ($tableCount == $maxTables) {
-                        break;
-                    }
+                    $params['join'] = $joinPaths;
                 }
-                $params['join'] = $joinPaths;
+                if ($hasRelationFilter) {
+                    $params = $this->limitFilterDepth($params, $maxDepth);
+                }
                 $request = RequestUtils::setParams($request, $params);
                 VariableStore::set("joinLimits.maxRecords", $maxRecords);
             }
@@ -7294,6 +7369,102 @@ namespace Tqdev\PhpCrudApi\Record\Condition {
     }
 }
 
+// file: src/Tqdev/PhpCrudApi/Record/Condition/RelatedCondition.php
+namespace Tqdev\PhpCrudApi\Record\Condition {
+    use Tqdev\PhpCrudApi\Column\Reflection\ReflectedColumn;
+    use Tqdev\PhpCrudApi\Column\Reflection\ReflectedTable;
+    /**
+     * Condition that filters the queried (outer) table by a condition on a related
+     * table. It is rendered as a correlated "EXISTS" sub-query so that the outer
+     * record is kept only when at least one matching related record exists. This is
+     * how v3 supports filters on joined/child tables while keeping pagination and
+     * count correct on the outer table.
+     *
+     * Three relation kinds are supported, mirroring the RelationJoiner:
+     * - 'belongsTo': outer table has a foreign key to the related table.
+     * - 'hasMany':   related table has a foreign key to the outer table.
+     * - 'habtm':     outer and related table are linked by a junction table.
+     */
+    class RelatedCondition extends Condition
+    {
+        private $kind;
+        private $outerColumn;
+        private $relatedTable;
+        private $relatedColumn;
+        private $junctionTable;
+        private $junctionToOuterColumn;
+        private $junctionToRelatedColumn;
+        private $condition;
+        private function __construct(
+            string $kind,
+            ReflectedColumn $outerColumn,
+            ReflectedTable $relatedTable,
+            ReflectedColumn $relatedColumn,
+            /* ?ReflectedTable */
+            $junctionTable,
+            /* ?ReflectedColumn */
+            $junctionToOuterColumn,
+            /* ?ReflectedColumn */
+            $junctionToRelatedColumn,
+            Condition $condition
+        )
+        {
+            $this->kind = $kind;
+            $this->outerColumn = $outerColumn;
+            $this->relatedTable = $relatedTable;
+            $this->relatedColumn = $relatedColumn;
+            $this->junctionTable = $junctionTable;
+            $this->junctionToOuterColumn = $junctionToOuterColumn;
+            $this->junctionToRelatedColumn = $junctionToRelatedColumn;
+            $this->condition = $condition;
+        }
+        public static function belongsTo(ReflectedColumn $outerFk, ReflectedTable $relatedTable, ReflectedColumn $relatedPk, Condition $condition): RelatedCondition
+        {
+            return new RelatedCondition('belongsTo', $outerFk, $relatedTable, $relatedPk, null, null, null, $condition);
+        }
+        public static function hasMany(ReflectedColumn $outerPk, ReflectedTable $relatedTable, ReflectedColumn $relatedFk, Condition $condition): RelatedCondition
+        {
+            return new RelatedCondition('hasMany', $outerPk, $relatedTable, $relatedFk, null, null, null, $condition);
+        }
+        public static function habtm(ReflectedColumn $outerPk, ReflectedTable $relatedTable, ReflectedColumn $relatedPk, ReflectedTable $junctionTable, ReflectedColumn $junctionToOuter, ReflectedColumn $junctionToRelated, Condition $condition): RelatedCondition
+        {
+            return new RelatedCondition('habtm', $outerPk, $relatedTable, $relatedPk, $junctionTable, $junctionToOuter, $junctionToRelated, $condition);
+        }
+        public function getKind(): string
+        {
+            return $this->kind;
+        }
+        public function getOuterColumn(): ReflectedColumn
+        {
+            return $this->outerColumn;
+        }
+        public function getRelatedTable(): ReflectedTable
+        {
+            return $this->relatedTable;
+        }
+        public function getRelatedColumn(): ReflectedColumn
+        {
+            return $this->relatedColumn;
+        }
+        public function getJunctionTable()
+        {
+            return $this->junctionTable;
+        }
+        public function getJunctionToOuterColumn()
+        {
+            return $this->junctionToOuterColumn;
+        }
+        public function getJunctionToRelatedColumn()
+        {
+            return $this->junctionToRelatedColumn;
+        }
+        public function getCondition(): Condition
+        {
+            return $this->condition;
+        }
+    }
+}
+
 // file: src/Tqdev/PhpCrudApi/Record/Condition/SpatialCondition.php
 namespace Tqdev\PhpCrudApi\Record\Condition {
     class SpatialCondition extends ColumnCondition
@@ -7456,12 +7627,82 @@ namespace Tqdev\PhpCrudApi\Record {
 // file: src/Tqdev/PhpCrudApi/Record/FilterInfo.php
 namespace Tqdev\PhpCrudApi\Record {
     use Tqdev\PhpCrudApi\Column\Reflection\ReflectedTable;
+    use Tqdev\PhpCrudApi\Column\ReflectionService;
+    use Tqdev\PhpCrudApi\Middleware\Communication\VariableStore;
     use Tqdev\PhpCrudApi\Record\Condition\AndCondition;
     use Tqdev\PhpCrudApi\Record\Condition\Condition;
     use Tqdev\PhpCrudApi\Record\Condition\NoCondition;
     use Tqdev\PhpCrudApi\Record\Condition\OrCondition;
     class FilterInfo
     {
+        private $resolver;
+        public function __construct(ReflectionService $reflection = null)
+        {
+            $this->resolver = $reflection ? new RelationResolver($reflection) : null;
+        }
+        /**
+         * Builds a condition from a single "filter" value. When the column part
+         * contains a relation path (e.g. "comments.message"), it is compiled into a
+         * RelatedCondition (correlated EXISTS) on the related table. Otherwise it is
+         * a plain condition on the queried table, identical to v2.
+         */
+        private function conditionFromString(ReflectedTable $table, string $filter): Condition
+        {
+            $parts = explode(',', $filter, 3);
+            if (count($parts) < 2) {
+                return new NoCondition();
+            }
+            $fieldPath = $parts[0];
+            if ($this->resolver === null || strpos($fieldPath, '.') === false) {
+                return Condition::fromString($table, $filter);
+            }
+            $segments = explode('.', $fieldPath);
+            $columnName = array_pop($segments);
+            // walk the relation path to find the related (leaf) table
+            $tables = array($table);
+            foreach ($segments as $tableName) {
+                $relatedTable = $this->resolver->getRelatedTable($tables[count($tables) - 1], $tableName);
+                if ($relatedTable === null) {
+                    return new NoCondition();
+                }
+                $tables[] = $relatedTable;
+            }
+            $leafTable = $tables[count($tables) - 1];
+            if (!$leafTable->hasColumn($columnName)) {
+                return new NoCondition();
+            }
+            $command = $parts[1];
+            $value = isset($parts[2]) ? $parts[2] : '';
+            $condition = Condition::fromString($leafTable, $columnName . ',' . $command . ',' . $value);
+            if ($condition instanceof NoCondition) {
+                return $condition;
+            }
+            // wrap the leaf condition in a RelatedCondition per hop, from leaf to
+            // root. at each hop the related table's authorization and multi-tenancy
+            // conditions are applied inside the sub-query, just like they are on a
+            // direct query of that table (see GenericDB::addMiddlewareConditions)
+            for ($i = count($segments) - 1; $i >= 0; $i--) {
+                $condition = $this->addMiddlewareConditions($tables[$i + 1], $condition);
+                $condition = $this->resolver->relate($tables[$i], $segments[$i], $condition);
+                if ($condition === null) {
+                    return new NoCondition();
+                }
+            }
+            return $condition;
+        }
+        private function addMiddlewareConditions(ReflectedTable $table, Condition $condition): Condition
+        {
+            $tableName = $table->getName();
+            $authorization = VariableStore::get("authorization.conditions.{$tableName}");
+            if ($authorization) {
+                $condition = $condition->_and($authorization);
+            }
+            $multiTenancy = VariableStore::get("multiTenancy.conditions.{$tableName}");
+            if ($multiTenancy) {
+                $condition = $condition->_and($multiTenancy);
+            }
+            return $condition;
+        }
         private function getConditionsAsPathTree(ReflectedTable $table, array $params): PathTree
         {
             $conditions = new PathTree();
@@ -7470,7 +7711,7 @@ namespace Tqdev\PhpCrudApi\Record {
                     preg_match_all('/\d+|\D+/', substr($key, 6), $matches);
                     $path = $matches[0];
                     foreach ($filters as $filter) {
-                        $condition = Condition::fromString($table, $filter);
+                        $condition = $this->conditionFromString($table, $filter);
                         if ($condition instanceof NoCondition == false) {
                             $conditions->put($path, $condition);
                         }
@@ -7717,7 +7958,7 @@ namespace Tqdev\PhpCrudApi\Record {
             $this->reflection = $reflection;
             $this->columns = new ColumnIncluder();
             $this->joiner = new RelationJoiner($reflection, $this->columns);
-            $this->filters = new FilterInfo();
+            $this->filters = new FilterInfo($reflection);
             $this->ordering = new OrderingInfo();
             $this->pagination = new PaginationInfo();
         }
@@ -8117,6 +8358,95 @@ namespace Tqdev\PhpCrudApi\Record {
     }
 }
 
+// file: src/Tqdev/PhpCrudApi/Record/RelationResolver.php
+namespace Tqdev\PhpCrudApi\Record {
+    use Tqdev\PhpCrudApi\Column\Reflection\ReflectedTable;
+    use Tqdev\PhpCrudApi\Column\ReflectionService;
+    use Tqdev\PhpCrudApi\Record\Condition\Condition;
+    use Tqdev\PhpCrudApi\Record\Condition\RelatedCondition;
+    /**
+     * Resolves a single relation hop from one table to a related table by name,
+     * using the same belongsTo/hasMany/hasAndBelongsToMany detection as the
+     * RelationJoiner. Used to compile filters that target related tables into
+     * RelatedCondition (correlated EXISTS) trees.
+     */
+    class RelationResolver
+    {
+        private $reflection;
+        public function __construct(ReflectionService $reflection)
+        {
+            $this->reflection = $reflection;
+        }
+        private function hasAndBelongsToMany(ReflectedTable $t1, ReflectedTable $t2)
+        {
+            foreach ($this->reflection->getTableNames() as $tableName) {
+                $t3 = $this->reflection->getTable($tableName);
+                if (count($t3->getFksTo($t1->getName())) > 0 && count($t3->getFksTo($t2->getName())) > 0) {
+                    return $t3;
+                }
+            }
+            return null;
+        }
+        /**
+         * Returns the related table reachable from $t1 under the name $t2Name, or
+         * null when there is no such table or no relation between them.
+         */
+        public function getRelatedTable(ReflectedTable $t1, string $t2Name)
+        {
+            if (!$this->reflection->hasTable($t2Name)) {
+                return null;
+            }
+            $t2 = $this->reflection->getTable($t2Name);
+            $belongsTo = count($t1->getFksTo($t2->getName())) > 0;
+            $hasMany = count($t2->getFksTo($t1->getName())) > 0;
+            $habtm = !$belongsTo && !$hasMany ? $this->hasAndBelongsToMany($t1, $t2) != null : false;
+            if (!$belongsTo && !$hasMany && !$habtm) {
+                return null;
+            }
+            return $t2;
+        }
+        /**
+         * Wraps $inner (a condition on the related table) in a RelatedCondition that
+         * correlates the related table $t2Name back to $t1. Returns null when the
+         * relation cannot be resolved or required keys are missing.
+         */
+        public function relate(ReflectedTable $t1, string $t2Name, Condition $inner)
+        {
+            if (!$this->reflection->hasTable($t2Name)) {
+                return null;
+            }
+            $t2 = $this->reflection->getTable($t2Name);
+            $fks1 = $t1->getFksTo($t2->getName());
+            if (count($fks1) > 0) {
+                // belongsTo: t1 has a foreign key referencing t2's primary key
+                if (!$t2->hasPk()) {
+                    return null;
+                }
+                return RelatedCondition::belongsTo($fks1[0], $t2, $t2->getPk(), $inner);
+            }
+            $fks2 = $t2->getFksTo($t1->getName());
+            if (count($fks2) > 0) {
+                // hasMany: t2 has a foreign key referencing t1's primary key
+                if (!$t1->hasPk()) {
+                    return null;
+                }
+                return RelatedCondition::hasMany($t1->getPk(), $t2, $fks2[0], $inner);
+            }
+            $t3 = $this->hasAndBelongsToMany($t1, $t2);
+            if ($t3 != null) {
+                // habtm: junction table t3 references both t1 and t2 primary keys
+                if (!$t1->hasPk() || !$t2->hasPk()) {
+                    return null;
+                }
+                $junctionToOuter = $t3->getFksTo($t1->getName())[0];
+                $junctionToRelated = $t3->getFksTo($t2->getName())[0];
+                return RelatedCondition::habtm($t1->getPk(), $t2, $t2->getPk(), $t3, $junctionToOuter, $junctionToRelated, $inner);
+            }
+            return null;
+        }
+    }
+}
+
 // file: src/Tqdev/PhpCrudApi/RequestFactory.php
 namespace Tqdev\PhpCrudApi {
     use Nyholm\Psr7\Factory\Psr17Factory;
@@ -8232,6 +8562,30 @@ namespace Tqdev\PhpCrudApi {
             }
             return array_keys($uniqueTableNames);
         }
+        private static function getFilterTables(array $parameters, ReflectionService $reflection): array
+        {
+            $uniqueTableNames = array();
+            foreach ($parameters as $key => $values) {
+                if (substr($key, 0, 6) != 'filter' || !is_array($values)) {
+                    continue;
+                }
+                foreach ($values as $value) {
+                    $columnPath = explode(',', $value, 2)[0];
+                    if (strpos($columnPath, '.') === false) {
+                        continue;
+                    }
+                    $segments = explode('.', $columnPath);
+                    array_pop($segments);
+                    // last segment is the column name
+                    foreach ($segments as $segment) {
+                        if ($reflection->hasTable($segment)) {
+                            $uniqueTableNames[$segment] = true;
+                        }
+                    }
+                }
+            }
+            return array_keys($uniqueTableNames);
+        }
         public static function getTableNames(ServerRequestInterface $request, ReflectionService $reflection): array
         {
             $path = RequestUtils::getPathSegment($request, 1);
@@ -8243,7 +8597,16 @@ namespace Tqdev\PhpCrudApi {
                 case 'columns':
                     return $tableName ? [$tableName] : $allTableNames;
                 case 'records':
-                    return self::getJoinTables($tableName, RequestUtils::getParams($request));
+                    $params = RequestUtils::getParams($request);
+                    $tableNames = self::getJoinTables($tableName, $params);
+                    // tables referenced by filters on related tables must also be
+                    // authorized, so they are included here
+                    foreach (self::getFilterTables($params, $reflection) as $filterTable) {
+                        if (!in_array($filterTable, $tableNames)) {
+                            $tableNames[] = $filterTable;
+                        }
+                    }
+                    return $tableNames;
             }
             return $allTableNames;
         }

--- a/api.php
+++ b/api.php
@@ -2267,67 +2267,98 @@ namespace Tqdev\PhpCrudApi\Database {
     use Tqdev\PhpCrudApi\Record\Condition\NoCondition;
     use Tqdev\PhpCrudApi\Record\Condition\NotCondition;
     use Tqdev\PhpCrudApi\Record\Condition\OrCondition;
+    use Tqdev\PhpCrudApi\Record\Condition\RelatedCondition;
     use Tqdev\PhpCrudApi\Record\Condition\SpatialCondition;
     class ConditionsBuilder
     {
         private $driver;
         private $geometrySrid;
+        private $aliasSeq;
         public function __construct(string $driver, int $geometrySrid)
         {
             $this->driver = $driver;
             $this->geometrySrid = $geometrySrid;
+            $this->aliasSeq = 0;
         }
-        private function getConditionSql(Condition $condition, array &$arguments): string
+        private function nextAlias(): string
+        {
+            return '_cf' . $this->aliasSeq++;
+        }
+        private function getConditionSql(Condition $condition, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
         {
             if ($condition instanceof AndCondition) {
-                return $this->getAndConditionSql($condition, $arguments);
+                return $this->getAndConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             if ($condition instanceof OrCondition) {
-                return $this->getOrConditionSql($condition, $arguments);
+                return $this->getOrConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             if ($condition instanceof NotCondition) {
-                return $this->getNotConditionSql($condition, $arguments);
+                return $this->getNotConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             if ($condition instanceof SpatialCondition) {
-                return $this->getSpatialConditionSql($condition, $arguments);
+                return $this->getSpatialConditionSql($condition, $arguments, $columnAlias);
+            }
+            if ($condition instanceof RelatedCondition) {
+                return $this->getRelatedConditionSql($condition, $arguments, $correlationRef);
             }
             if ($condition instanceof ColumnCondition) {
-                return $this->getColumnConditionSql($condition, $arguments);
+                return $this->getColumnConditionSql($condition, $arguments, $columnAlias);
             }
             throw new \Exception('Unknown Condition: ' . get_class($condition));
         }
-        private function getAndConditionSql(AndCondition $and, array &$arguments): string
+        private function getAndConditionSql(AndCondition $and, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
         {
             $parts = [];
             foreach ($and->getConditions() as $condition) {
-                $parts[] = $this->getConditionSql($condition, $arguments);
+                $parts[] = $this->getConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             return '(' . implode(' AND ', $parts) . ')';
         }
-        private function getOrConditionSql(OrCondition $or, array &$arguments): string
+        private function getOrConditionSql(OrCondition $or, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
         {
             $parts = [];
             foreach ($or->getConditions() as $condition) {
-                $parts[] = $this->getConditionSql($condition, $arguments);
+                $parts[] = $this->getConditionSql($condition, $arguments, $columnAlias, $correlationRef);
             }
             return '(' . implode(' OR ', $parts) . ')';
         }
-        private function getNotConditionSql(NotCondition $not, array &$arguments): string
+        private function getNotConditionSql(NotCondition $not, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
         {
             $condition = $not->getCondition();
-            return '(NOT ' . $this->getConditionSql($condition, $arguments) . ')';
+            return '(NOT ' . $this->getConditionSql($condition, $arguments, $columnAlias, $correlationRef) . ')';
         }
-        private function quoteColumnName(ReflectedColumn $column): string
+        private function quoteColumnName(ReflectedColumn $column, string $alias = ''): string
         {
+            if ($alias !== '') {
+                return '"' . $alias . '"."' . $column->getRealName() . '"';
+            }
             return '"' . $column->getRealName() . '"';
+        }
+        private function getRelatedConditionSql(RelatedCondition $condition, array &$arguments, string $correlationRef): string
+        {
+            $relatedTable = '"' . $condition->getRelatedTable()->getRealName() . '"';
+            $outerRef = $correlationRef . '.' . $this->quoteColumnName($condition->getOuterColumn());
+            if ($condition->getKind() === 'habtm') {
+                $junctionAlias = $this->nextAlias();
+                $relatedAlias = $this->nextAlias();
+                $junctionTable = '"' . $condition->getJunctionTable()->getRealName() . '"';
+                $joinOn = $this->quoteColumnName($condition->getRelatedColumn(), $relatedAlias) . ' = ' . $this->quoteColumnName($condition->getJunctionToRelatedColumn(), $junctionAlias);
+                $correlate = $this->quoteColumnName($condition->getJunctionToOuterColumn(), $junctionAlias) . ' = ' . $outerRef;
+                $inner = $this->getConditionSql($condition->getCondition(), $arguments, $relatedAlias, '"' . $relatedAlias . '"');
+                return 'EXISTS (SELECT 1 FROM ' . $junctionTable . ' "' . $junctionAlias . '" JOIN ' . $relatedTable . ' "' . $relatedAlias . '" ON ' . $joinOn . ' WHERE ' . $correlate . ' AND ' . $inner . ')';
+            }
+            $relatedAlias = $this->nextAlias();
+            $correlate = $this->quoteColumnName($condition->getRelatedColumn(), $relatedAlias) . ' = ' . $outerRef;
+            $inner = $this->getConditionSql($condition->getCondition(), $arguments, $relatedAlias, '"' . $relatedAlias . '"');
+            return 'EXISTS (SELECT 1 FROM ' . $relatedTable . ' "' . $relatedAlias . '" WHERE ' . $correlate . ' AND ' . $inner . ')';
         }
         private function escapeLikeValue(string $value): string
         {
             return addcslashes($value, '%_');
         }
-        private function getColumnConditionSql(ColumnCondition $condition, array &$arguments): string
+        private function getColumnConditionSql(ColumnCondition $condition, array &$arguments, string $columnAlias = ''): string
         {
-            $column = $this->quoteColumnName($condition->getColumn());
+            $column = $this->quoteColumnName($condition->getColumn(), $columnAlias);
             $operator = $condition->getOperator();
             $value = $condition->getValue();
             $sql = 'FALSE';
@@ -2440,9 +2471,9 @@ namespace Tqdev\PhpCrudApi\Database {
             }
             return '';
         }
-        private function getSpatialConditionSql(ColumnCondition $condition, array &$arguments): string
+        private function getSpatialConditionSql(ColumnCondition $condition, array &$arguments, string $columnAlias = ''): string
         {
-            $column = $this->quoteColumnName($condition->getColumn());
+            $column = $this->quoteColumnName($condition->getColumn(), $columnAlias);
             $operator = $condition->getOperator();
             $value = $condition->getValue();
             $functionName = $this->getSpatialFunctionName($operator);
@@ -2453,12 +2484,13 @@ namespace Tqdev\PhpCrudApi\Database {
             }
             return $sql;
         }
-        public function getWhereClause(Condition $condition, array &$arguments): string
+        public function getWhereClause(Condition $condition, array &$arguments, string $tableRef = ''): string
         {
             if ($condition instanceof NoCondition) {
                 return '';
             }
-            return ' WHERE ' . $this->getConditionSql($condition, $arguments);
+            $this->aliasSeq = 0;
+            return ' WHERE ' . $this->getConditionSql($condition, $arguments, '', $tableRef);
         }
     }
 }
@@ -2818,7 +2850,7 @@ namespace Tqdev\PhpCrudApi\Database {
             $tableRealName = $table->getRealName();
             $condition = $this->addMiddlewareConditions($tableName, $condition);
             $parameters = array();
-            $whereClause = $this->conditions->getWhereClause($condition, $parameters);
+            $whereClause = $this->conditions->getWhereClause($condition, $parameters, '"' . $tableRealName . '"');
             $sql = 'SELECT COUNT(*) FROM "' . $tableRealName . '"' . $whereClause;
             $stmt = $this->query($sql, $parameters);
             return $stmt->fetchColumn(0);
@@ -2845,7 +2877,7 @@ namespace Tqdev\PhpCrudApi\Database {
             $tableRealName = $table->getRealName();
             $condition = $this->addMiddlewareConditions($tableName, $condition);
             $parameters = array();
-            $whereClause = $this->conditions->getWhereClause($condition, $parameters);
+            $whereClause = $this->conditions->getWhereClause($condition, $parameters, '"' . $tableRealName . '"');
             $orderBy = $this->columns->getOrderBy($table, $columnOrdering);
             $offsetLimit = $this->columns->getOffsetLimit($offset, $limit);
             $sql = 'SELECT ' . $selectColumns . ' FROM "' . $tableRealName . '"' . $whereClause . $orderBy . $offsetLimit;
@@ -4937,32 +4969,75 @@ namespace Tqdev\PhpCrudApi\Middleware {
         {
             parent::__construct($router, $responder, $config, $middleware);
         }
+        private function hasRelationFilter(array $params): bool
+        {
+            foreach ($params as $key => $values) {
+                if (substr($key, 0, 6) != 'filter' || !is_array($values)) {
+                    continue;
+                }
+                foreach ($values as $value) {
+                    if (strpos(explode(',', $value, 2)[0], '.') !== false) {
+                        return true;
+                    }
+                }
+            }
+            return false;
+        }
+        private function limitFilterDepth(array $params, int $maxDepth): array
+        {
+            foreach ($params as $key => $values) {
+                if (substr($key, 0, 6) != 'filter' || !is_array($values)) {
+                    continue;
+                }
+                $kept = array();
+                foreach ($values as $value) {
+                    // the number of dots in the column path equals the number of
+                    // related tables traversed, mirroring the join depth limit
+                    if (substr_count(explode(',', $value, 2)[0], '.') <= $maxDepth) {
+                        $kept[] = $value;
+                    }
+                }
+                if (count($kept) > 0) {
+                    $params[$key] = $kept;
+                } else {
+                    unset($params[$key]);
+                }
+            }
+            return $params;
+        }
         public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface
         {
             $operation = RequestUtils::getOperation($request);
             $params = RequestUtils::getParams($request);
-            if (in_array($operation, ['read', 'list']) && isset($params['join'])) {
+            $hasJoin = isset($params['join']);
+            $hasRelationFilter = $this->hasRelationFilter($params);
+            if (in_array($operation, ['read', 'list']) && ($hasJoin || $hasRelationFilter)) {
                 $maxDepth = (int) $this->getProperty('depth', '3');
                 $maxTables = (int) $this->getProperty('tables', '10');
                 $maxRecords = (int) $this->getProperty('records', '1000');
-                $tableCount = 0;
-                $joinPaths = array();
-                for ($i = 0; $i < count($params['join']); $i++) {
-                    $joinPath = array();
-                    $tables = explode(',', $params['join'][$i]);
-                    for ($depth = 0; $depth < min($maxDepth, count($tables)); $depth++) {
-                        array_push($joinPath, $tables[$depth]);
-                        $tableCount += 1;
+                if ($hasJoin) {
+                    $tableCount = 0;
+                    $joinPaths = array();
+                    for ($i = 0; $i < count($params['join']); $i++) {
+                        $joinPath = array();
+                        $tables = explode(',', $params['join'][$i]);
+                        for ($depth = 0; $depth < min($maxDepth, count($tables)); $depth++) {
+                            array_push($joinPath, $tables[$depth]);
+                            $tableCount += 1;
+                            if ($tableCount == $maxTables) {
+                                break;
+                            }
+                        }
+                        array_push($joinPaths, implode(',', $joinPath));
                         if ($tableCount == $maxTables) {
                             break;
                         }
                     }
-                    array_push($joinPaths, implode(',', $joinPath));
-                    if ($tableCount == $maxTables) {
-                        break;
-                    }
+                    $params['join'] = $joinPaths;
                 }
-                $params['join'] = $joinPaths;
+                if ($hasRelationFilter) {
+                    $params = $this->limitFilterDepth($params, $maxDepth);
+                }
                 $request = RequestUtils::setParams($request, $params);
                 VariableStore::set("joinLimits.maxRecords", $maxRecords);
             }
@@ -7294,6 +7369,102 @@ namespace Tqdev\PhpCrudApi\Record\Condition {
     }
 }
 
+// file: src/Tqdev/PhpCrudApi/Record/Condition/RelatedCondition.php
+namespace Tqdev\PhpCrudApi\Record\Condition {
+    use Tqdev\PhpCrudApi\Column\Reflection\ReflectedColumn;
+    use Tqdev\PhpCrudApi\Column\Reflection\ReflectedTable;
+    /**
+     * Condition that filters the queried (outer) table by a condition on a related
+     * table. It is rendered as a correlated "EXISTS" sub-query so that the outer
+     * record is kept only when at least one matching related record exists. This is
+     * how v3 supports filters on joined/child tables while keeping pagination and
+     * count correct on the outer table.
+     *
+     * Three relation kinds are supported, mirroring the RelationJoiner:
+     * - 'belongsTo': outer table has a foreign key to the related table.
+     * - 'hasMany':   related table has a foreign key to the outer table.
+     * - 'habtm':     outer and related table are linked by a junction table.
+     */
+    class RelatedCondition extends Condition
+    {
+        private $kind;
+        private $outerColumn;
+        private $relatedTable;
+        private $relatedColumn;
+        private $junctionTable;
+        private $junctionToOuterColumn;
+        private $junctionToRelatedColumn;
+        private $condition;
+        private function __construct(
+            string $kind,
+            ReflectedColumn $outerColumn,
+            ReflectedTable $relatedTable,
+            ReflectedColumn $relatedColumn,
+            /* ?ReflectedTable */
+            $junctionTable,
+            /* ?ReflectedColumn */
+            $junctionToOuterColumn,
+            /* ?ReflectedColumn */
+            $junctionToRelatedColumn,
+            Condition $condition
+        )
+        {
+            $this->kind = $kind;
+            $this->outerColumn = $outerColumn;
+            $this->relatedTable = $relatedTable;
+            $this->relatedColumn = $relatedColumn;
+            $this->junctionTable = $junctionTable;
+            $this->junctionToOuterColumn = $junctionToOuterColumn;
+            $this->junctionToRelatedColumn = $junctionToRelatedColumn;
+            $this->condition = $condition;
+        }
+        public static function belongsTo(ReflectedColumn $outerFk, ReflectedTable $relatedTable, ReflectedColumn $relatedPk, Condition $condition): RelatedCondition
+        {
+            return new RelatedCondition('belongsTo', $outerFk, $relatedTable, $relatedPk, null, null, null, $condition);
+        }
+        public static function hasMany(ReflectedColumn $outerPk, ReflectedTable $relatedTable, ReflectedColumn $relatedFk, Condition $condition): RelatedCondition
+        {
+            return new RelatedCondition('hasMany', $outerPk, $relatedTable, $relatedFk, null, null, null, $condition);
+        }
+        public static function habtm(ReflectedColumn $outerPk, ReflectedTable $relatedTable, ReflectedColumn $relatedPk, ReflectedTable $junctionTable, ReflectedColumn $junctionToOuter, ReflectedColumn $junctionToRelated, Condition $condition): RelatedCondition
+        {
+            return new RelatedCondition('habtm', $outerPk, $relatedTable, $relatedPk, $junctionTable, $junctionToOuter, $junctionToRelated, $condition);
+        }
+        public function getKind(): string
+        {
+            return $this->kind;
+        }
+        public function getOuterColumn(): ReflectedColumn
+        {
+            return $this->outerColumn;
+        }
+        public function getRelatedTable(): ReflectedTable
+        {
+            return $this->relatedTable;
+        }
+        public function getRelatedColumn(): ReflectedColumn
+        {
+            return $this->relatedColumn;
+        }
+        public function getJunctionTable()
+        {
+            return $this->junctionTable;
+        }
+        public function getJunctionToOuterColumn()
+        {
+            return $this->junctionToOuterColumn;
+        }
+        public function getJunctionToRelatedColumn()
+        {
+            return $this->junctionToRelatedColumn;
+        }
+        public function getCondition(): Condition
+        {
+            return $this->condition;
+        }
+    }
+}
+
 // file: src/Tqdev/PhpCrudApi/Record/Condition/SpatialCondition.php
 namespace Tqdev\PhpCrudApi\Record\Condition {
     class SpatialCondition extends ColumnCondition
@@ -7456,12 +7627,82 @@ namespace Tqdev\PhpCrudApi\Record {
 // file: src/Tqdev/PhpCrudApi/Record/FilterInfo.php
 namespace Tqdev\PhpCrudApi\Record {
     use Tqdev\PhpCrudApi\Column\Reflection\ReflectedTable;
+    use Tqdev\PhpCrudApi\Column\ReflectionService;
+    use Tqdev\PhpCrudApi\Middleware\Communication\VariableStore;
     use Tqdev\PhpCrudApi\Record\Condition\AndCondition;
     use Tqdev\PhpCrudApi\Record\Condition\Condition;
     use Tqdev\PhpCrudApi\Record\Condition\NoCondition;
     use Tqdev\PhpCrudApi\Record\Condition\OrCondition;
     class FilterInfo
     {
+        private $resolver;
+        public function __construct(ReflectionService $reflection = null)
+        {
+            $this->resolver = $reflection ? new RelationResolver($reflection) : null;
+        }
+        /**
+         * Builds a condition from a single "filter" value. When the column part
+         * contains a relation path (e.g. "comments.message"), it is compiled into a
+         * RelatedCondition (correlated EXISTS) on the related table. Otherwise it is
+         * a plain condition on the queried table, identical to v2.
+         */
+        private function conditionFromString(ReflectedTable $table, string $filter): Condition
+        {
+            $parts = explode(',', $filter, 3);
+            if (count($parts) < 2) {
+                return new NoCondition();
+            }
+            $fieldPath = $parts[0];
+            if ($this->resolver === null || strpos($fieldPath, '.') === false) {
+                return Condition::fromString($table, $filter);
+            }
+            $segments = explode('.', $fieldPath);
+            $columnName = array_pop($segments);
+            // walk the relation path to find the related (leaf) table
+            $tables = array($table);
+            foreach ($segments as $tableName) {
+                $relatedTable = $this->resolver->getRelatedTable($tables[count($tables) - 1], $tableName);
+                if ($relatedTable === null) {
+                    return new NoCondition();
+                }
+                $tables[] = $relatedTable;
+            }
+            $leafTable = $tables[count($tables) - 1];
+            if (!$leafTable->hasColumn($columnName)) {
+                return new NoCondition();
+            }
+            $command = $parts[1];
+            $value = isset($parts[2]) ? $parts[2] : '';
+            $condition = Condition::fromString($leafTable, $columnName . ',' . $command . ',' . $value);
+            if ($condition instanceof NoCondition) {
+                return $condition;
+            }
+            // wrap the leaf condition in a RelatedCondition per hop, from leaf to
+            // root. at each hop the related table's authorization and multi-tenancy
+            // conditions are applied inside the sub-query, just like they are on a
+            // direct query of that table (see GenericDB::addMiddlewareConditions)
+            for ($i = count($segments) - 1; $i >= 0; $i--) {
+                $condition = $this->addMiddlewareConditions($tables[$i + 1], $condition);
+                $condition = $this->resolver->relate($tables[$i], $segments[$i], $condition);
+                if ($condition === null) {
+                    return new NoCondition();
+                }
+            }
+            return $condition;
+        }
+        private function addMiddlewareConditions(ReflectedTable $table, Condition $condition): Condition
+        {
+            $tableName = $table->getName();
+            $authorization = VariableStore::get("authorization.conditions.{$tableName}");
+            if ($authorization) {
+                $condition = $condition->_and($authorization);
+            }
+            $multiTenancy = VariableStore::get("multiTenancy.conditions.{$tableName}");
+            if ($multiTenancy) {
+                $condition = $condition->_and($multiTenancy);
+            }
+            return $condition;
+        }
         private function getConditionsAsPathTree(ReflectedTable $table, array $params): PathTree
         {
             $conditions = new PathTree();
@@ -7470,7 +7711,7 @@ namespace Tqdev\PhpCrudApi\Record {
                     preg_match_all('/\d+|\D+/', substr($key, 6), $matches);
                     $path = $matches[0];
                     foreach ($filters as $filter) {
-                        $condition = Condition::fromString($table, $filter);
+                        $condition = $this->conditionFromString($table, $filter);
                         if ($condition instanceof NoCondition == false) {
                             $conditions->put($path, $condition);
                         }
@@ -7717,7 +7958,7 @@ namespace Tqdev\PhpCrudApi\Record {
             $this->reflection = $reflection;
             $this->columns = new ColumnIncluder();
             $this->joiner = new RelationJoiner($reflection, $this->columns);
-            $this->filters = new FilterInfo();
+            $this->filters = new FilterInfo($reflection);
             $this->ordering = new OrderingInfo();
             $this->pagination = new PaginationInfo();
         }
@@ -8117,6 +8358,95 @@ namespace Tqdev\PhpCrudApi\Record {
     }
 }
 
+// file: src/Tqdev/PhpCrudApi/Record/RelationResolver.php
+namespace Tqdev\PhpCrudApi\Record {
+    use Tqdev\PhpCrudApi\Column\Reflection\ReflectedTable;
+    use Tqdev\PhpCrudApi\Column\ReflectionService;
+    use Tqdev\PhpCrudApi\Record\Condition\Condition;
+    use Tqdev\PhpCrudApi\Record\Condition\RelatedCondition;
+    /**
+     * Resolves a single relation hop from one table to a related table by name,
+     * using the same belongsTo/hasMany/hasAndBelongsToMany detection as the
+     * RelationJoiner. Used to compile filters that target related tables into
+     * RelatedCondition (correlated EXISTS) trees.
+     */
+    class RelationResolver
+    {
+        private $reflection;
+        public function __construct(ReflectionService $reflection)
+        {
+            $this->reflection = $reflection;
+        }
+        private function hasAndBelongsToMany(ReflectedTable $t1, ReflectedTable $t2)
+        {
+            foreach ($this->reflection->getTableNames() as $tableName) {
+                $t3 = $this->reflection->getTable($tableName);
+                if (count($t3->getFksTo($t1->getName())) > 0 && count($t3->getFksTo($t2->getName())) > 0) {
+                    return $t3;
+                }
+            }
+            return null;
+        }
+        /**
+         * Returns the related table reachable from $t1 under the name $t2Name, or
+         * null when there is no such table or no relation between them.
+         */
+        public function getRelatedTable(ReflectedTable $t1, string $t2Name)
+        {
+            if (!$this->reflection->hasTable($t2Name)) {
+                return null;
+            }
+            $t2 = $this->reflection->getTable($t2Name);
+            $belongsTo = count($t1->getFksTo($t2->getName())) > 0;
+            $hasMany = count($t2->getFksTo($t1->getName())) > 0;
+            $habtm = !$belongsTo && !$hasMany ? $this->hasAndBelongsToMany($t1, $t2) != null : false;
+            if (!$belongsTo && !$hasMany && !$habtm) {
+                return null;
+            }
+            return $t2;
+        }
+        /**
+         * Wraps $inner (a condition on the related table) in a RelatedCondition that
+         * correlates the related table $t2Name back to $t1. Returns null when the
+         * relation cannot be resolved or required keys are missing.
+         */
+        public function relate(ReflectedTable $t1, string $t2Name, Condition $inner)
+        {
+            if (!$this->reflection->hasTable($t2Name)) {
+                return null;
+            }
+            $t2 = $this->reflection->getTable($t2Name);
+            $fks1 = $t1->getFksTo($t2->getName());
+            if (count($fks1) > 0) {
+                // belongsTo: t1 has a foreign key referencing t2's primary key
+                if (!$t2->hasPk()) {
+                    return null;
+                }
+                return RelatedCondition::belongsTo($fks1[0], $t2, $t2->getPk(), $inner);
+            }
+            $fks2 = $t2->getFksTo($t1->getName());
+            if (count($fks2) > 0) {
+                // hasMany: t2 has a foreign key referencing t1's primary key
+                if (!$t1->hasPk()) {
+                    return null;
+                }
+                return RelatedCondition::hasMany($t1->getPk(), $t2, $fks2[0], $inner);
+            }
+            $t3 = $this->hasAndBelongsToMany($t1, $t2);
+            if ($t3 != null) {
+                // habtm: junction table t3 references both t1 and t2 primary keys
+                if (!$t1->hasPk() || !$t2->hasPk()) {
+                    return null;
+                }
+                $junctionToOuter = $t3->getFksTo($t1->getName())[0];
+                $junctionToRelated = $t3->getFksTo($t2->getName())[0];
+                return RelatedCondition::habtm($t1->getPk(), $t2, $t2->getPk(), $t3, $junctionToOuter, $junctionToRelated, $inner);
+            }
+            return null;
+        }
+    }
+}
+
 // file: src/Tqdev/PhpCrudApi/RequestFactory.php
 namespace Tqdev\PhpCrudApi {
     use Nyholm\Psr7\Factory\Psr17Factory;
@@ -8232,6 +8562,30 @@ namespace Tqdev\PhpCrudApi {
             }
             return array_keys($uniqueTableNames);
         }
+        private static function getFilterTables(array $parameters, ReflectionService $reflection): array
+        {
+            $uniqueTableNames = array();
+            foreach ($parameters as $key => $values) {
+                if (substr($key, 0, 6) != 'filter' || !is_array($values)) {
+                    continue;
+                }
+                foreach ($values as $value) {
+                    $columnPath = explode(',', $value, 2)[0];
+                    if (strpos($columnPath, '.') === false) {
+                        continue;
+                    }
+                    $segments = explode('.', $columnPath);
+                    array_pop($segments);
+                    // last segment is the column name
+                    foreach ($segments as $segment) {
+                        if ($reflection->hasTable($segment)) {
+                            $uniqueTableNames[$segment] = true;
+                        }
+                    }
+                }
+            }
+            return array_keys($uniqueTableNames);
+        }
         public static function getTableNames(ServerRequestInterface $request, ReflectionService $reflection): array
         {
             $path = RequestUtils::getPathSegment($request, 1);
@@ -8243,7 +8597,16 @@ namespace Tqdev\PhpCrudApi {
                 case 'columns':
                     return $tableName ? [$tableName] : $allTableNames;
                 case 'records':
-                    return self::getJoinTables($tableName, RequestUtils::getParams($request));
+                    $params = RequestUtils::getParams($request);
+                    $tableNames = self::getJoinTables($tableName, $params);
+                    // tables referenced by filters on related tables must also be
+                    // authorized, so they are included here
+                    foreach (self::getFilterTables($params, $reflection) as $filterTable) {
+                        if (!in_array($filterTable, $tableNames)) {
+                            $tableNames[] = $filterTable;
+                        }
+                    }
+                    return $tableNames;
             }
             return $allTableNames;
         }

--- a/src/Tqdev/PhpCrudApi/Database/ConditionsBuilder.php
+++ b/src/Tqdev/PhpCrudApi/Database/ConditionsBuilder.php
@@ -9,66 +9,99 @@ use Tqdev\PhpCrudApi\Record\Condition\Condition;
 use Tqdev\PhpCrudApi\Record\Condition\NoCondition;
 use Tqdev\PhpCrudApi\Record\Condition\NotCondition;
 use Tqdev\PhpCrudApi\Record\Condition\OrCondition;
+use Tqdev\PhpCrudApi\Record\Condition\RelatedCondition;
 use Tqdev\PhpCrudApi\Record\Condition\SpatialCondition;
 
 class ConditionsBuilder
 {
     private $driver;
     private $geometrySrid;
+    private $aliasSeq;
 
     public function __construct(string $driver, int $geometrySrid)
     {
         $this->driver = $driver;
         $this->geometrySrid = $geometrySrid;
+        $this->aliasSeq = 0;
     }
 
-    private function getConditionSql(Condition $condition, array &$arguments): string
+    private function nextAlias(): string
+    {
+        return '_cf' . $this->aliasSeq++;
+    }
+
+    private function getConditionSql(Condition $condition, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
     {
         if ($condition instanceof AndCondition) {
-            return $this->getAndConditionSql($condition, $arguments);
+            return $this->getAndConditionSql($condition, $arguments, $columnAlias, $correlationRef);
         }
         if ($condition instanceof OrCondition) {
-            return $this->getOrConditionSql($condition, $arguments);
+            return $this->getOrConditionSql($condition, $arguments, $columnAlias, $correlationRef);
         }
         if ($condition instanceof NotCondition) {
-            return $this->getNotConditionSql($condition, $arguments);
+            return $this->getNotConditionSql($condition, $arguments, $columnAlias, $correlationRef);
         }
         if ($condition instanceof SpatialCondition) {
-            return $this->getSpatialConditionSql($condition, $arguments);
+            return $this->getSpatialConditionSql($condition, $arguments, $columnAlias);
+        }
+        if ($condition instanceof RelatedCondition) {
+            return $this->getRelatedConditionSql($condition, $arguments, $correlationRef);
         }
         if ($condition instanceof ColumnCondition) {
-            return $this->getColumnConditionSql($condition, $arguments);
+            return $this->getColumnConditionSql($condition, $arguments, $columnAlias);
         }
         throw new \Exception('Unknown Condition: ' . get_class($condition));
     }
 
-    private function getAndConditionSql(AndCondition $and, array &$arguments): string
+    private function getAndConditionSql(AndCondition $and, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
     {
         $parts = [];
         foreach ($and->getConditions() as $condition) {
-            $parts[] = $this->getConditionSql($condition, $arguments);
+            $parts[] = $this->getConditionSql($condition, $arguments, $columnAlias, $correlationRef);
         }
         return '(' . implode(' AND ', $parts) . ')';
     }
 
-    private function getOrConditionSql(OrCondition $or, array &$arguments): string
+    private function getOrConditionSql(OrCondition $or, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
     {
         $parts = [];
         foreach ($or->getConditions() as $condition) {
-            $parts[] = $this->getConditionSql($condition, $arguments);
+            $parts[] = $this->getConditionSql($condition, $arguments, $columnAlias, $correlationRef);
         }
         return '(' . implode(' OR ', $parts) . ')';
     }
 
-    private function getNotConditionSql(NotCondition $not, array &$arguments): string
+    private function getNotConditionSql(NotCondition $not, array &$arguments, string $columnAlias = '', string $correlationRef = ''): string
     {
         $condition = $not->getCondition();
-        return '(NOT ' . $this->getConditionSql($condition, $arguments) . ')';
+        return '(NOT ' . $this->getConditionSql($condition, $arguments, $columnAlias, $correlationRef) . ')';
     }
 
-    private function quoteColumnName(ReflectedColumn $column): string
+    private function quoteColumnName(ReflectedColumn $column, string $alias = ''): string
     {
+        if ($alias !== '') {
+            return '"' . $alias . '"."' . $column->getRealName() . '"';
+        }
         return '"' . $column->getRealName() . '"';
+    }
+
+    private function getRelatedConditionSql(RelatedCondition $condition, array &$arguments, string $correlationRef): string
+    {
+        $relatedTable = '"' . $condition->getRelatedTable()->getRealName() . '"';
+        $outerRef = $correlationRef . '.' . $this->quoteColumnName($condition->getOuterColumn());
+        if ($condition->getKind() === 'habtm') {
+            $junctionAlias = $this->nextAlias();
+            $relatedAlias = $this->nextAlias();
+            $junctionTable = '"' . $condition->getJunctionTable()->getRealName() . '"';
+            $joinOn = $this->quoteColumnName($condition->getRelatedColumn(), $relatedAlias) . ' = ' . $this->quoteColumnName($condition->getJunctionToRelatedColumn(), $junctionAlias);
+            $correlate = $this->quoteColumnName($condition->getJunctionToOuterColumn(), $junctionAlias) . ' = ' . $outerRef;
+            $inner = $this->getConditionSql($condition->getCondition(), $arguments, $relatedAlias, '"' . $relatedAlias . '"');
+            return 'EXISTS (SELECT 1 FROM ' . $junctionTable . ' "' . $junctionAlias . '" JOIN ' . $relatedTable . ' "' . $relatedAlias . '" ON ' . $joinOn . ' WHERE ' . $correlate . ' AND ' . $inner . ')';
+        }
+        $relatedAlias = $this->nextAlias();
+        $correlate = $this->quoteColumnName($condition->getRelatedColumn(), $relatedAlias) . ' = ' . $outerRef;
+        $inner = $this->getConditionSql($condition->getCondition(), $arguments, $relatedAlias, '"' . $relatedAlias . '"');
+        return 'EXISTS (SELECT 1 FROM ' . $relatedTable . ' "' . $relatedAlias . '" WHERE ' . $correlate . ' AND ' . $inner . ')';
     }
 
     private function escapeLikeValue(string $value): string
@@ -76,9 +109,9 @@ class ConditionsBuilder
         return addcslashes($value, '%_');
     }
 
-    private function getColumnConditionSql(ColumnCondition $condition, array &$arguments): string
+    private function getColumnConditionSql(ColumnCondition $condition, array &$arguments, string $columnAlias = ''): string
     {
-        $column = $this->quoteColumnName($condition->getColumn());
+        $column = $this->quoteColumnName($condition->getColumn(), $columnAlias);
         $operator = $condition->getOperator();
         $value = $condition->getValue();
         $sql = 'FALSE';
@@ -195,9 +228,9 @@ class ConditionsBuilder
         return '';
     }
 
-    private function getSpatialConditionSql(ColumnCondition $condition, array &$arguments): string
+    private function getSpatialConditionSql(ColumnCondition $condition, array &$arguments, string $columnAlias = ''): string
     {
-        $column = $this->quoteColumnName($condition->getColumn());
+        $column = $this->quoteColumnName($condition->getColumn(), $columnAlias);
         $operator = $condition->getOperator();
         $value = $condition->getValue();
         $functionName = $this->getSpatialFunctionName($operator);
@@ -209,11 +242,12 @@ class ConditionsBuilder
         return $sql;
     }
 
-    public function getWhereClause(Condition $condition, array &$arguments): string
+    public function getWhereClause(Condition $condition, array &$arguments, string $tableRef = ''): string
     {
         if ($condition instanceof NoCondition) {
             return '';
         }
-        return ' WHERE ' . $this->getConditionSql($condition, $arguments);
+        $this->aliasSeq = 0;
+        return ' WHERE ' . $this->getConditionSql($condition, $arguments, '', $tableRef);
     }
 }

--- a/src/Tqdev/PhpCrudApi/Database/GenericDB.php
+++ b/src/Tqdev/PhpCrudApi/Database/GenericDB.php
@@ -293,7 +293,7 @@ class GenericDB
         $tableRealName = $table->getRealName();
         $condition = $this->addMiddlewareConditions($tableName, $condition);
         $parameters = array();
-        $whereClause = $this->conditions->getWhereClause($condition, $parameters);
+        $whereClause = $this->conditions->getWhereClause($condition, $parameters, '"' . $tableRealName . '"');
         $sql = 'SELECT COUNT(*) FROM "' . $tableRealName . '"' . $whereClause;
         $stmt = $this->query($sql, $parameters);
         return $stmt->fetchColumn(0);
@@ -322,7 +322,7 @@ class GenericDB
         $tableRealName = $table->getRealName();
         $condition = $this->addMiddlewareConditions($tableName, $condition);
         $parameters = array();
-        $whereClause = $this->conditions->getWhereClause($condition, $parameters);
+        $whereClause = $this->conditions->getWhereClause($condition, $parameters, '"' . $tableRealName . '"');
         $orderBy = $this->columns->getOrderBy($table, $columnOrdering);
         $offsetLimit = $this->columns->getOffsetLimit($offset, $limit);
         $sql = 'SELECT ' . $selectColumns . ' FROM "' . $tableRealName . '"' . $whereClause . $orderBy . $offsetLimit;

--- a/src/Tqdev/PhpCrudApi/Middleware/JoinLimitsMiddleware.php
+++ b/src/Tqdev/PhpCrudApi/Middleware/JoinLimitsMiddleware.php
@@ -19,32 +19,77 @@ class JoinLimitsMiddleware extends Middleware
         parent::__construct($router, $responder, $config, $middleware);
     }
 
+    private function hasRelationFilter(array $params): bool
+    {
+        foreach ($params as $key => $values) {
+            if (substr($key, 0, 6) != 'filter' || !is_array($values)) {
+                continue;
+            }
+            foreach ($values as $value) {
+                if (strpos(explode(',', $value, 2)[0], '.') !== false) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    private function limitFilterDepth(array $params, int $maxDepth): array
+    {
+        foreach ($params as $key => $values) {
+            if (substr($key, 0, 6) != 'filter' || !is_array($values)) {
+                continue;
+            }
+            $kept = array();
+            foreach ($values as $value) {
+                // the number of dots in the column path equals the number of
+                // related tables traversed, mirroring the join depth limit
+                if (substr_count(explode(',', $value, 2)[0], '.') <= $maxDepth) {
+                    $kept[] = $value;
+                }
+            }
+            if (count($kept) > 0) {
+                $params[$key] = $kept;
+            } else {
+                unset($params[$key]);
+            }
+        }
+        return $params;
+    }
+
     public function process(ServerRequestInterface $request, RequestHandlerInterface $next): ResponseInterface
     {
         $operation = RequestUtils::getOperation($request);
         $params = RequestUtils::getParams($request);
-        if (in_array($operation, ['read', 'list']) && isset($params['join'])) {
+        $hasJoin = isset($params['join']);
+        $hasRelationFilter = $this->hasRelationFilter($params);
+        if (in_array($operation, ['read', 'list']) && ($hasJoin || $hasRelationFilter)) {
             $maxDepth = (int) $this->getProperty('depth', '3');
             $maxTables = (int) $this->getProperty('tables', '10');
             $maxRecords = (int) $this->getProperty('records', '1000');
-            $tableCount = 0;
-            $joinPaths = array();
-            for ($i = 0; $i < count($params['join']); $i++) {
-                $joinPath = array();
-                $tables = explode(',', $params['join'][$i]);
-                for ($depth = 0; $depth < min($maxDepth, count($tables)); $depth++) {
-                    array_push($joinPath, $tables[$depth]);
-                    $tableCount += 1;
+            if ($hasJoin) {
+                $tableCount = 0;
+                $joinPaths = array();
+                for ($i = 0; $i < count($params['join']); $i++) {
+                    $joinPath = array();
+                    $tables = explode(',', $params['join'][$i]);
+                    for ($depth = 0; $depth < min($maxDepth, count($tables)); $depth++) {
+                        array_push($joinPath, $tables[$depth]);
+                        $tableCount += 1;
+                        if ($tableCount == $maxTables) {
+                            break;
+                        }
+                    }
+                    array_push($joinPaths, implode(',', $joinPath));
                     if ($tableCount == $maxTables) {
                         break;
                     }
                 }
-                array_push($joinPaths, implode(',', $joinPath));
-                if ($tableCount == $maxTables) {
-                    break;
-                }
+                $params['join'] = $joinPaths;
             }
-            $params['join'] = $joinPaths;
+            if ($hasRelationFilter) {
+                $params = $this->limitFilterDepth($params, $maxDepth);
+            }
             $request = RequestUtils::setParams($request, $params);
             VariableStore::set("joinLimits.maxRecords", $maxRecords);
         }

--- a/src/Tqdev/PhpCrudApi/Record/Condition/RelatedCondition.php
+++ b/src/Tqdev/PhpCrudApi/Record/Condition/RelatedCondition.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace Tqdev\PhpCrudApi\Record\Condition;
+
+use Tqdev\PhpCrudApi\Column\Reflection\ReflectedColumn;
+use Tqdev\PhpCrudApi\Column\Reflection\ReflectedTable;
+
+/**
+ * Condition that filters the queried (outer) table by a condition on a related
+ * table. It is rendered as a correlated "EXISTS" sub-query so that the outer
+ * record is kept only when at least one matching related record exists. This is
+ * how v3 supports filters on joined/child tables while keeping pagination and
+ * count correct on the outer table.
+ *
+ * Three relation kinds are supported, mirroring the RelationJoiner:
+ * - 'belongsTo': outer table has a foreign key to the related table.
+ * - 'hasMany':   related table has a foreign key to the outer table.
+ * - 'habtm':     outer and related table are linked by a junction table.
+ */
+class RelatedCondition extends Condition
+{
+    private $kind;
+    private $outerColumn;
+    private $relatedTable;
+    private $relatedColumn;
+    private $junctionTable;
+    private $junctionToOuterColumn;
+    private $junctionToRelatedColumn;
+    private $condition;
+
+    private function __construct(
+        string $kind,
+        ReflectedColumn $outerColumn,
+        ReflectedTable $relatedTable,
+        ReflectedColumn $relatedColumn,
+        /* ?ReflectedTable */ $junctionTable,
+        /* ?ReflectedColumn */ $junctionToOuterColumn,
+        /* ?ReflectedColumn */ $junctionToRelatedColumn,
+        Condition $condition
+    ) {
+        $this->kind = $kind;
+        $this->outerColumn = $outerColumn;
+        $this->relatedTable = $relatedTable;
+        $this->relatedColumn = $relatedColumn;
+        $this->junctionTable = $junctionTable;
+        $this->junctionToOuterColumn = $junctionToOuterColumn;
+        $this->junctionToRelatedColumn = $junctionToRelatedColumn;
+        $this->condition = $condition;
+    }
+
+    public static function belongsTo(ReflectedColumn $outerFk, ReflectedTable $relatedTable, ReflectedColumn $relatedPk, Condition $condition): RelatedCondition
+    {
+        return new RelatedCondition('belongsTo', $outerFk, $relatedTable, $relatedPk, null, null, null, $condition);
+    }
+
+    public static function hasMany(ReflectedColumn $outerPk, ReflectedTable $relatedTable, ReflectedColumn $relatedFk, Condition $condition): RelatedCondition
+    {
+        return new RelatedCondition('hasMany', $outerPk, $relatedTable, $relatedFk, null, null, null, $condition);
+    }
+
+    public static function habtm(ReflectedColumn $outerPk, ReflectedTable $relatedTable, ReflectedColumn $relatedPk, ReflectedTable $junctionTable, ReflectedColumn $junctionToOuter, ReflectedColumn $junctionToRelated, Condition $condition): RelatedCondition
+    {
+        return new RelatedCondition('habtm', $outerPk, $relatedTable, $relatedPk, $junctionTable, $junctionToOuter, $junctionToRelated, $condition);
+    }
+
+    public function getKind(): string
+    {
+        return $this->kind;
+    }
+
+    public function getOuterColumn(): ReflectedColumn
+    {
+        return $this->outerColumn;
+    }
+
+    public function getRelatedTable(): ReflectedTable
+    {
+        return $this->relatedTable;
+    }
+
+    public function getRelatedColumn(): ReflectedColumn
+    {
+        return $this->relatedColumn;
+    }
+
+    public function getJunctionTable() /*: ?ReflectedTable*/
+    {
+        return $this->junctionTable;
+    }
+
+    public function getJunctionToOuterColumn() /*: ?ReflectedColumn*/
+    {
+        return $this->junctionToOuterColumn;
+    }
+
+    public function getJunctionToRelatedColumn() /*: ?ReflectedColumn*/
+    {
+        return $this->junctionToRelatedColumn;
+    }
+
+    public function getCondition(): Condition
+    {
+        return $this->condition;
+    }
+}

--- a/src/Tqdev/PhpCrudApi/Record/FilterInfo.php
+++ b/src/Tqdev/PhpCrudApi/Record/FilterInfo.php
@@ -3,6 +3,8 @@
 namespace Tqdev\PhpCrudApi\Record;
 
 use Tqdev\PhpCrudApi\Column\Reflection\ReflectedTable;
+use Tqdev\PhpCrudApi\Column\ReflectionService;
+use Tqdev\PhpCrudApi\Middleware\Communication\VariableStore;
 use Tqdev\PhpCrudApi\Record\Condition\AndCondition;
 use Tqdev\PhpCrudApi\Record\Condition\Condition;
 use Tqdev\PhpCrudApi\Record\Condition\NoCondition;
@@ -10,6 +12,78 @@ use Tqdev\PhpCrudApi\Record\Condition\OrCondition;
 
 class FilterInfo
 {
+    private $resolver;
+
+    public function __construct(ReflectionService $reflection = null)
+    {
+        $this->resolver = $reflection ? new RelationResolver($reflection) : null;
+    }
+
+    /**
+     * Builds a condition from a single "filter" value. When the column part
+     * contains a relation path (e.g. "comments.message"), it is compiled into a
+     * RelatedCondition (correlated EXISTS) on the related table. Otherwise it is
+     * a plain condition on the queried table, identical to v2.
+     */
+    private function conditionFromString(ReflectedTable $table, string $filter): Condition
+    {
+        $parts = explode(',', $filter, 3);
+        if (count($parts) < 2) {
+            return new NoCondition();
+        }
+        $fieldPath = $parts[0];
+        if ($this->resolver === null || strpos($fieldPath, '.') === false) {
+            return Condition::fromString($table, $filter);
+        }
+        $segments = explode('.', $fieldPath);
+        $columnName = array_pop($segments);
+        // walk the relation path to find the related (leaf) table
+        $tables = array($table);
+        foreach ($segments as $tableName) {
+            $relatedTable = $this->resolver->getRelatedTable($tables[count($tables) - 1], $tableName);
+            if ($relatedTable === null) {
+                return new NoCondition();
+            }
+            $tables[] = $relatedTable;
+        }
+        $leafTable = $tables[count($tables) - 1];
+        if (!$leafTable->hasColumn($columnName)) {
+            return new NoCondition();
+        }
+        $command = $parts[1];
+        $value = isset($parts[2]) ? $parts[2] : '';
+        $condition = Condition::fromString($leafTable, $columnName . ',' . $command . ',' . $value);
+        if ($condition instanceof NoCondition) {
+            return $condition;
+        }
+        // wrap the leaf condition in a RelatedCondition per hop, from leaf to
+        // root. at each hop the related table's authorization and multi-tenancy
+        // conditions are applied inside the sub-query, just like they are on a
+        // direct query of that table (see GenericDB::addMiddlewareConditions)
+        for ($i = count($segments) - 1; $i >= 0; $i--) {
+            $condition = $this->addMiddlewareConditions($tables[$i + 1], $condition);
+            $condition = $this->resolver->relate($tables[$i], $segments[$i], $condition);
+            if ($condition === null) {
+                return new NoCondition();
+            }
+        }
+        return $condition;
+    }
+
+    private function addMiddlewareConditions(ReflectedTable $table, Condition $condition): Condition
+    {
+        $tableName = $table->getName();
+        $authorization = VariableStore::get("authorization.conditions.$tableName");
+        if ($authorization) {
+            $condition = $condition->_and($authorization);
+        }
+        $multiTenancy = VariableStore::get("multiTenancy.conditions.$tableName");
+        if ($multiTenancy) {
+            $condition = $condition->_and($multiTenancy);
+        }
+        return $condition;
+    }
+
     private function getConditionsAsPathTree(ReflectedTable $table, array $params): PathTree
     {
         $conditions = new PathTree();
@@ -18,7 +92,7 @@ class FilterInfo
                 preg_match_all('/\d+|\D+/', substr($key, 6), $matches);
                 $path = $matches[0];
                 foreach ($filters as $filter) {
-                    $condition = Condition::fromString($table, $filter);
+                    $condition = $this->conditionFromString($table, $filter);
                     if (($condition instanceof NoCondition) == false) {
                         $conditions->put($path, $condition);
                     }

--- a/src/Tqdev/PhpCrudApi/Record/RecordService.php
+++ b/src/Tqdev/PhpCrudApi/Record/RecordService.php
@@ -22,7 +22,7 @@ class RecordService
         $this->reflection = $reflection;
         $this->columns = new ColumnIncluder();
         $this->joiner = new RelationJoiner($reflection, $this->columns);
-        $this->filters = new FilterInfo();
+        $this->filters = new FilterInfo($reflection);
         $this->ordering = new OrderingInfo();
         $this->pagination = new PaginationInfo();
     }

--- a/src/Tqdev/PhpCrudApi/Record/RelationResolver.php
+++ b/src/Tqdev/PhpCrudApi/Record/RelationResolver.php
@@ -1,0 +1,98 @@
+<?php
+
+namespace Tqdev\PhpCrudApi\Record;
+
+use Tqdev\PhpCrudApi\Column\Reflection\ReflectedTable;
+use Tqdev\PhpCrudApi\Column\ReflectionService;
+use Tqdev\PhpCrudApi\Record\Condition\Condition;
+use Tqdev\PhpCrudApi\Record\Condition\RelatedCondition;
+
+/**
+ * Resolves a single relation hop from one table to a related table by name,
+ * using the same belongsTo/hasMany/hasAndBelongsToMany detection as the
+ * RelationJoiner. Used to compile filters that target related tables into
+ * RelatedCondition (correlated EXISTS) trees.
+ */
+class RelationResolver
+{
+    private $reflection;
+
+    public function __construct(ReflectionService $reflection)
+    {
+        $this->reflection = $reflection;
+    }
+
+    private function hasAndBelongsToMany(ReflectedTable $t1, ReflectedTable $t2) /*: ?ReflectedTable*/
+    {
+        foreach ($this->reflection->getTableNames() as $tableName) {
+            $t3 = $this->reflection->getTable($tableName);
+            if (count($t3->getFksTo($t1->getName())) > 0 && count($t3->getFksTo($t2->getName())) > 0) {
+                return $t3;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Returns the related table reachable from $t1 under the name $t2Name, or
+     * null when there is no such table or no relation between them.
+     */
+    public function getRelatedTable(ReflectedTable $t1, string $t2Name) /*: ?ReflectedTable*/
+    {
+        if (!$this->reflection->hasTable($t2Name)) {
+            return null;
+        }
+        $t2 = $this->reflection->getTable($t2Name);
+        $belongsTo = count($t1->getFksTo($t2->getName())) > 0;
+        $hasMany = count($t2->getFksTo($t1->getName())) > 0;
+        $habtm = (!$belongsTo && !$hasMany) ? ($this->hasAndBelongsToMany($t1, $t2) != null) : false;
+        if (!$belongsTo && !$hasMany && !$habtm) {
+            return null;
+        }
+        return $t2;
+    }
+
+    /**
+     * Wraps $inner (a condition on the related table) in a RelatedCondition that
+     * correlates the related table $t2Name back to $t1. Returns null when the
+     * relation cannot be resolved or required keys are missing.
+     */
+    public function relate(ReflectedTable $t1, string $t2Name, Condition $inner) /*: ?RelatedCondition*/
+    {
+        if (!$this->reflection->hasTable($t2Name)) {
+            return null;
+        }
+        $t2 = $this->reflection->getTable($t2Name);
+
+        $fks1 = $t1->getFksTo($t2->getName());
+        if (count($fks1) > 0) {
+            // belongsTo: t1 has a foreign key referencing t2's primary key
+            if (!$t2->hasPk()) {
+                return null;
+            }
+            return RelatedCondition::belongsTo($fks1[0], $t2, $t2->getPk(), $inner);
+        }
+
+        $fks2 = $t2->getFksTo($t1->getName());
+        if (count($fks2) > 0) {
+            // hasMany: t2 has a foreign key referencing t1's primary key
+            if (!$t1->hasPk()) {
+                return null;
+            }
+            return RelatedCondition::hasMany($t1->getPk(), $t2, $fks2[0], $inner);
+        }
+
+        $t3 = $this->hasAndBelongsToMany($t1, $t2);
+        if ($t3 != null) {
+            // habtm: junction table t3 references both t1 and t2 primary keys
+            if (!$t1->hasPk() || !$t2->hasPk()) {
+                return null;
+            }
+            $junctionToOuter = $t3->getFksTo($t1->getName())[0];
+            $junctionToRelated = $t3->getFksTo($t2->getName())[0];
+            return RelatedCondition::habtm($t1->getPk(), $t2, $t2->getPk(), $t3, $junctionToOuter, $junctionToRelated, $inner);
+        }
+
+        return null;
+    }
+}

--- a/src/Tqdev/PhpCrudApi/RequestUtils.php
+++ b/src/Tqdev/PhpCrudApi/RequestUtils.php
@@ -82,6 +82,30 @@ class RequestUtils
         return array_keys($uniqueTableNames);
     }
 
+    private static function getFilterTables(array $parameters, ReflectionService $reflection): array
+    {
+        $uniqueTableNames = array();
+        foreach ($parameters as $key => $values) {
+            if (substr($key, 0, 6) != 'filter' || !is_array($values)) {
+                continue;
+            }
+            foreach ($values as $value) {
+                $columnPath = explode(',', $value, 2)[0];
+                if (strpos($columnPath, '.') === false) {
+                    continue;
+                }
+                $segments = explode('.', $columnPath);
+                array_pop($segments); // last segment is the column name
+                foreach ($segments as $segment) {
+                    if ($reflection->hasTable($segment)) {
+                        $uniqueTableNames[$segment] = true;
+                    }
+                }
+            }
+        }
+        return array_keys($uniqueTableNames);
+    }
+
     public static function getTableNames(ServerRequestInterface $request, ReflectionService $reflection): array
     {
         $path = RequestUtils::getPathSegment($request, 1);
@@ -93,7 +117,16 @@ class RequestUtils
             case 'columns':
                 return $tableName ? [$tableName] : $allTableNames;
             case 'records':
-                return self::getJoinTables($tableName, RequestUtils::getParams($request));
+                $params = RequestUtils::getParams($request);
+                $tableNames = self::getJoinTables($tableName, $params);
+                // tables referenced by filters on related tables must also be
+                // authorized, so they are included here
+                foreach (self::getFilterTables($params, $reflection) as $filterTable) {
+                    if (!in_array($filterTable, $tableNames)) {
+                        $tableNames[] = $filterTable;
+                    }
+                }
+                return $tableNames;
         }
         return $allTableNames;
     }

--- a/tests/functional/001_records/096_list_posts_filter_on_hasmany_child.log
+++ b/tests/functional/001_records/096_list_posts_filter_on_hasmany_child.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?include=id&filter=comments.message,cs,great
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 22
+
+{"records":[{"id":1}]}

--- a/tests/functional/001_records/097_list_posts_filter_on_belongsto_parent.log
+++ b/tests/functional/001_records/097_list_posts_filter_on_belongsto_parent.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?include=id&filter=categories.name,eq,article
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 22
+
+{"records":[{"id":2}]}

--- a/tests/functional/001_records/098_list_posts_filter_on_habtm_child.log
+++ b/tests/functional/001_records/098_list_posts_filter_on_habtm_child.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?include=id&filter=tags.name,eq,funny
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 31
+
+{"records":[{"id":1},{"id":2}]}

--- a/tests/functional/001_records/099_list_posts_filter_on_nested_child.log
+++ b/tests/functional/001_records/099_list_posts_filter_on_nested_child.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?include=id&filter=comments.categories.name,eq,comment
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 40
+
+{"records":[{"id":1},{"id":2},{"id":6}]}

--- a/tests/functional/001_records/100_list_posts_child_filter_keeps_all_children.log
+++ b/tests/functional/001_records/100_list_posts_child_filter_keeps_all_children.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?join=comments&filter=comments.message,cs,great
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 202
+
+{"records":[{"id":1,"user_id":1,"category_id":1,"content":"blog started","comments":[{"id":1,"post_id":1,"message":"great","category_id":3},{"id":2,"post_id":1,"message":"fantastic","category_id":3}]}]}

--- a/tests/functional/001_records/101_list_posts_child_filter_with_pagination.log
+++ b/tests/functional/001_records/101_list_posts_child_filter_with_pagination.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?include=id&filter=comments.message,cs,thank&page=1,10
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 34
+
+{"records":[{"id":2}],"results":1}

--- a/tests/functional/001_records/102_list_posts_child_filter_or_grouping.log
+++ b/tests/functional/001_records/102_list_posts_child_filter_or_grouping.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?include=id&filter1=comments.message,cs,great&filter2=categories.name,eq,article
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 31
+
+{"records":[{"id":1},{"id":2}]}

--- a/tests/functional/001_records/103_list_posts_negated_hasmany_child_filter.log
+++ b/tests/functional/001_records/103_list_posts_negated_hasmany_child_filter.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?include=id&filter=comments.message,ncs,great
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 40
+
+{"records":[{"id":1},{"id":2},{"id":6}]}

--- a/tests/functional/001_records/104_list_posts_unknown_relation_filter_ignored.log
+++ b/tests/functional/001_records/104_list_posts_unknown_relation_filter_ignored.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?include=id&filter=nonexistent.name,eq,x
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 106
+
+{"records":[{"id":1},{"id":2},{"id":5},{"id":6},{"id":7},{"id":8},{"id":9},{"id":10},{"id":11},{"id":12}]}

--- a/tests/functional/001_records/105_list_posts_child_filter_respects_record_auth.log
+++ b/tests/functional/001_records/105_list_posts_child_filter_respects_record_auth.log
@@ -1,0 +1,8 @@
+===
+GET /records/posts?include=id&filter=comments.message,eq,invisible
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 14
+
+{"records":[]}

--- a/tests/functional/001_records/106_list_users_child_filter_respects_multi_tenancy.log
+++ b/tests/functional/001_records/106_list_users_child_filter_respects_multi_tenancy.log
@@ -1,0 +1,8 @@
+===
+GET /records/users?include=id&filter=kunsthåndværk.user_id,eq,2
+===
+200
+Content-Type: application/json; charset=utf-8
+Content-Length: 14
+
+{"records":[]}


### PR DESCRIPTION
List filters may now target a joined or child table by prefixing the column with the relation path, like filter=comments.message,cs,great. This works for belongsTo, hasMany and hasAndBelongsToMany relations and the path can be several tables deep.

The filter is translated into a correlated EXISTS sub-query, so it restricts the requested records (and the count and pagination) without changing the nested results, which still contain all related records. The related table does not need to be listed in the join parameter.

Authorization and multi-tenancy conditions of the related table are applied inside the sub-query, and related filter tables are included in authorization and join limit handling, so the feature does not bypass access rules.